### PR TITLE
adds beforeTeardown to story route's willTransition hook

### DIFF
--- a/app/channel/route.js
+++ b/app/channel/route.js
@@ -8,7 +8,7 @@ const {
 } = Ember;
 const { hash: waitFor } = Ember.RSVP;
 const inflector = new Inflector(Inflector.defaultRules);
-import { retryFromServer } from 'wnyc-web-client/lib/compat-hooks';
+import { retryFromServer, beforeTeardown } from 'wnyc-web-client/lib/compat-hooks';
 import PlayParamMixin from 'wnyc-web-client/mixins/play-param';
 
 export default Route.extend(PlayParamMixin, {
@@ -60,5 +60,13 @@ export default Route.extend(PlayParamMixin, {
       defaultSlug: navSlug,
       model
     });
+  },
+  
+  actions: {
+    willTransition() {
+      this._super(...arguments);
+      beforeTeardown();
+      return true;
+    }
   }
 });

--- a/app/story/route.js
+++ b/app/story/route.js
@@ -1,6 +1,7 @@
 import Ember from 'ember';
 import service from 'ember-service/inject';
 import PlayParamMixin from 'wnyc-web-client/mixins/play-param';
+import { beforeTeardown } from 'wnyc-web-client/lib/compat-hooks';
 const { get } = Ember;
 const { hash: waitFor } = Ember.RSVP;
 
@@ -56,5 +57,13 @@ export default Ember.Route.extend(PlayParamMixin, {
       nprVals,
       isNpr: true
     });
+  },
+  
+  actions: {
+    willTransition() {
+      this._super(...arguments);
+      beforeTeardown();
+      return true;
+    }
   }
 });


### PR DESCRIPTION
fixes story page and channel page legacy JS from working on
even-numbered visits due to unremoved listeners