### PR TITLE
WE 6593 continuous play banner

### DIFF
--- a/app/components/persistent-player/notification/template.hbs
+++ b/app/components/persistent-player/notification/template.hbs
@@ -1,15 +1,13 @@
 <div class='player-notification'>
-  {{#if preSwitch}}
     <p class='notification-message'>
+  {{#if preSwitch}}
       Your episode is over. In {{remaining}} seconds,
       {{#if streamEnabled}}
         we'll tune you to {{preferredStream.name}}.
       {{else}}
         your audio queue will begin to play.
       {{/if}}
-    </p>
   {{else}}
-      <p class='notification-message'>
         We
         {{#if streamEnabled}}
           tuned you to {{preferredStream.name}}
@@ -17,11 +15,7 @@
           began playing your audio queue
         {{/if}}
         after your episode ended.
-      </p>
   {{/if}}
-
-  <div class='notification-action'>
-    <div class='notification-change-settings'>
       <a href="/settings"
           title="Change Settings"
           data-tracking-category="Persistent Player"
@@ -30,8 +24,8 @@
           class='notification-link'
           >
           Change Settings</a>
-    </div>
-
+      </p>
+  <div class='notification-action'>
     <div class='dismiss-notification close-icon' {{action 'dismiss'}}>
       {{wnyc-svg icon='close'}}
     </div>

--- a/app/styles/_player-notification.scss
+++ b/app/styles/_player-notification.scss
@@ -12,7 +12,7 @@
   .notification-link {
     color: $gold;
     border-bottom: 1px solid rgba($gold, .3);
-    
+
     &:hover {
       border-bottom-color: rgba($gold, .8);
     }
@@ -64,8 +64,11 @@
 .notification-message {
   @include flex(1);
   margin: 0;
-  padding: 10px 10px 0 10px;
+  padding: 10px;
   align-self: center;
+  a {
+    margin-left: 10px;
+  }
 }
 
 // ipad messes with the alignment of the text a little bit

--- a/app/styles/_player-notification.scss
+++ b/app/styles/_player-notification.scss
@@ -66,9 +66,6 @@
   margin: 0;
   padding: 10px;
   align-self: center;
-  a {
-    margin-left: 10px;
-  }
 }
 
 // ipad messes with the alignment of the text a little bit

--- a/app/styles/_player-notification.scss
+++ b/app/styles/_player-notification.scss
@@ -22,7 +22,7 @@
     display: flex;
     justify-content: center;
     width: 100%;
-    padding-left: 20px;
+    padding: 0 21px;
   }
 
 
@@ -50,11 +50,11 @@
 }
 
 .notification-action {
+  @include flex(1 1 60px);
   display: flex;
   flex-flow: row;
-  flex-grow: 1;
-  justify-content: space-between;
-  min-width: 150px;
+  min-width: 60px;
+  max-width: 60px;
 }
 
 .notification-wrapper.liquid-container {
@@ -62,8 +62,9 @@
 }
 
 .notification-message {
+  @include flex(1);
   margin: 0;
-  padding: 10px;
+  padding: 10px 10px 0 10px;
   align-self: center;
 }
 

--- a/tests/integration/components/persistent-player/notification/component-test.js
+++ b/tests/integration/components/persistent-player/notification/component-test.js
@@ -37,8 +37,8 @@ test('it renders with the bumper duration countdown', function(assert) {
 
   this.render(hbs`{{persistent-player.notification duration=duration position=position audioType=audioType}}`);
 
-  let actualText = this.$('.player-notification p').text().trim().replace(/\s{2,}/, '');
-  let expectedText = 'Your episode is over. In 15 seconds,we\'ll tune you to .';
+  let actualText = this.$('.player-notification p').text().trim().replace(/\s{2,}/gm, ' ');
+  let expectedText = 'Your episode is over. In 15 seconds, we\'ll tune you to . Change Settings';
   assert.equal(actualText, expectedText);
 });
 
@@ -57,8 +57,7 @@ test('it renders after the bumper duration countdown', function(assert) {
   this.render(hbs`{{persistent-player.notification duration=duration position=position audioType=audioType}}`);
 
   // this kind of makes me NEVER want to split up text with conditional values at all in handlebars
-  let text = this.$('.player-notification p').text().trim();
-  let actualElapsedText = text.replace(/\n/, '').split(/\s{2,}/).join(' ');
-  let expectedElapsedText = 'We tuned you to after your episode ended.';
+  let actualElapsedText = this.$('.player-notification p').text().trim().replace(/\s{2,}/gm, ' ');
+  let expectedElapsedText = 'We tuned you to after your episode ended. Change Settings';
   assert.equal(actualElapsedText, expectedElapsedText);
 });


### PR DESCRIPTION
Move change settings link to be in the same line of text as the rest of the continuous play notification.  This should handle things like people who use smaller phones or larger font sizes better.

Also tweaked the margins of notification bar a bit to line up with player elements better. e.g. dismiss button  lined up with queue button.

https://jira.wnyc.org/browse/WE-6593