### PR TITLE
auth service compat

### DIFF
--- a/app/authenticators/nypr.js
+++ b/app/authenticators/nypr.js
@@ -2,5 +2,5 @@ import config from 'overhaul/config/environment';
 import OAuth2PasswordGrantAuthenticator from 'ember-simple-auth/authenticators/oauth2-password-grant';
 
 export default OAuth2PasswordGrantAuthenticator.extend({
-  serverTokenEndpoint: `${config.wnycAuthAPI}/session`
+  serverTokenEndpoint: `${config.wnycAuthAPI}/v1/session`
 });

--- a/app/components/account-reset-password-form/component.js
+++ b/app/components/account-reset-password-form/component.js
@@ -26,7 +26,7 @@ export default Component.extend({
     }
   },
   resetPassword(email, new_password, confirmation) {
-    let url = `${ENV.wnycAuthAPI}/auth/v1/confirm/password-reset`;
+    let url = `${ENV.wnycAuthAPI}/v1/confirm/password-reset`;
     let method = 'POST';
     let mode = 'cors';
     let headers = { "Content-Type" : "application/json" };

--- a/app/components/account-signup-form/component.js
+++ b/app/components/account-signup-form/component.js
@@ -42,7 +42,7 @@ export default Component.extend({
     }
   },
   resendConfirmationEmail(email) {
-    let url = `${ENV.wnycAuthAPI}/auth/v1/confirm/resend?email=${email}`;
+    let url = `${ENV.wnycAuthAPI}/v1/confirm/resend?email=${email}`;
     let method = 'GET';
     let mode = 'cors';
     return fetch(url, {method, mode})

--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -9,6 +9,7 @@ export default Route.extend(ApplicationRouteMixin, {
   asyncWriter: service(),
   legacyLoader: service(),
   leaderboard: service(),
+  currentUser: service(),
   session: service(),
   poll: service(),
   store: service(),
@@ -27,6 +28,7 @@ export default Route.extend(ApplicationRouteMixin, {
     let metrics = get(this, 'metrics');
 
     this._syncBrowserId();
+    get(this, 'currentUser').load();
 
     metrics.identify('GoogleAnalytics', {isAuthenticated: false});
 

--- a/app/services/current-user.js
+++ b/app/services/current-user.js
@@ -7,9 +7,8 @@ export default Service.extend({
 
   load() {
     if (this.get('session.isAuthenticated')) {
-      return this.get('store').find('user', 'me').then((user) => {
-        this.set('user', user);
-      });
+      let user = this.get('store').queryRecord('user', {me: true});
+      this.set('user', user);
     }
   }
 });

--- a/app/user/adapter.js
+++ b/app/user/adapter.js
@@ -7,9 +7,9 @@ export default DS.JSONAPIAdapter.extend(DataAdapterMixin, {
   host: ENV.wnycAuthAPI,
   buildURL(modelName, id, snapshot, requestType/*, query*/) {
     if (/createRecord|updateRecord/.test(requestType)) {
-      return `${this.host}/user`;
-    } else if (requestType.startsWith('find')) {
-      return `${this.host}/session`;
+      return `${this.host}/v1/user`;
+    } else if (requestType.startsWith('query')) {
+      return `${this.host}/v1/session`;
     }
   },
   normalizeErrorResponse(status, headers, payload) {

--- a/config/environment.js
+++ b/config/environment.js
@@ -105,7 +105,6 @@ module.exports = function(environment) {
     wnycURL: process.env.WNYC_URL,
     wnycDonateURL: 'https://pledge3.wnyc.org/donate/main/onestep/?utm_source=wnyc&utm_medium=wnyc-86x27&utm_content=wnyc-header-beta&utm_campaign=pledge',
     wnycSvgURL: '/media/svg/',
-    wnycAuthAPI: 'http://api.demo.nypr.digital',
     // put beta host at the root so it can be overridden by Django
     wnycBetaURL: process.env.WNYC_BETA_URL,
     featureFlags: {

--- a/mirage/config.js
+++ b/mirage/config.js
@@ -173,14 +173,14 @@ export default function() {
   
   this.urlPrefix = config.wnycAuthAPI;
   
-  this.get('/session', (schema, request) => {
+  this.get('/v1/session', (schema, request) => {
     if (!request.requestHeaders.Authorization) {
       return new Response(401);
     }
     return schema.users.first();
   });
   
-  this.patch('/user', (schema, request) => {
+  this.patch('/v1/user', (schema, request) => {
     if (!request.requestHeaders.Authorization) {
       return new Response(401);
     }

--- a/tests/acceptance/settings-authenticated-test.js
+++ b/tests/acceptance/settings-authenticated-test.js
@@ -8,7 +8,9 @@ import 'overhaul/tests/helpers/with-feature';
 
 moduleForAcceptance('Acceptance | settings', {
   beforeEach() {
-    authenticateSession(this.application);
+    server.create('user');
+    authenticateSession(this.application, {access_token: 'foo'});
+    
     let session = currentSession(this.application);
     session.set('data.user-prefs-active-stream', {slug: 'wqxr', name: 'WQXR New York'});
     session.set('data.user-prefs-active-autoplay', 'default_stream');

--- a/tests/acceptance/viewing-show-test.js
+++ b/tests/acceptance/viewing-show-test.js
@@ -36,7 +36,8 @@ test('smoke test', function(assert) {
 });
 
 test('authenticated smoke test', function(assert) {
-  authenticateSession(this.application, {is_staff: true});
+  server.create('user');
+  authenticateSession(this.application, {is_staff: true, access_token: 'foo'});
   let show = server.create('show', {
     id: 'shows/foo/',
     linkroll: [

--- a/tests/acceptance/viewing-story-test.js
+++ b/tests/acceptance/viewing-story-test.js
@@ -46,7 +46,8 @@ test('view comments as regular user', function(assert) {
 });
 
 test('view comments as staff user', function(assert) {
-  authenticateSession(this.application, {is_staff: true});
+  server.create('user');
+  authenticateSession(this.application, {is_staff: true, access_token: 'foo'});
   
   let story = server.create('story');
   let id = `story/${story.slug}/`;

--- a/tests/integration/components/account-reset-password-form/component-test.js
+++ b/tests/integration/components/account-reset-password-form/component-test.js
@@ -36,7 +36,7 @@ test('submitting the form sends the correct values to the correct endpoint', fun
 
   const request = this.requests[0];
 
-  const expectedUrl = `${ENV.wnycAuthAPI}/auth/v1/confirm/password-reset`;
+  const expectedUrl = `${ENV.wnycAuthAPI}/v1/confirm/password-reset`;
   const expectedMethod = 'POST';
 
   assert.equal(expectedUrl, request.url);


### PR DESCRIPTION
@walsh9, please take a look at this ticket for some updates related to auth service compatibility. 

Also take a look at the `load` method in the `current-user` service. I'm setting `user` as the promise returned by the store, so that in templates, we can do `currentUser.user` and ember will resolve know how to resolve the value. 

This might make for some hiccups when dealing with `currentUser.user` in JS code since the value will always need to be accessed via `Promise.resolve`, but since the `user` is itself a globally available value via the service, other parts of the app can't reliably `.then` off of it, AFAIK.