### PR TITLE
adds failing test for playing a stream from cold start

### DIFF
--- a/tests/acceptance/streams-test.js
+++ b/tests/acceptance/streams-test.js
@@ -3,20 +3,9 @@ import moduleForAcceptance from 'wnyc-web-client/tests/helpers/module-for-accept
 
 moduleForAcceptance('Acceptance | streams');
 
-let streamsRun = false;
-function setupStreams() {
-  if (streamsRun) {
-    // streams and whats-on items are linked via slug
-    // factories are set up to only with with the first 7 created
-    return;
-  }
-  streamsRun = true;
+test('visiting /streams', function(assert) {
   server.createList('stream', 7);
   server.createList('whats-on', 7);
-}
-
-test('visiting /streams', function(assert) {
-  setupStreams();
   
   visit('/streams');
 
@@ -27,7 +16,9 @@ test('visiting /streams', function(assert) {
 });
 
 test('playing a stream', function(assert) {
-  setupStreams();
+  server.createList('stream', 7);
+  server.createList('whats-on', 7);
+  
   visit('/streams');
   
   click('.stream-list li:first button');

--- a/tests/acceptance/streams-test.js
+++ b/tests/acceptance/streams-test.js
@@ -25,3 +25,14 @@ test('visiting /streams', function(assert) {
     assert.equal(find('.stream-list li').length, 7, 'should display a list of streams');
   });
 });
+
+test('playing a stream', function(assert) {
+  setupStreams();
+  visit('/streams');
+  
+  click('.stream-list li:first button');
+  
+  andThen(function() {
+    assert.ok(findWithAssert('.persistent-player'), 'persistent player should be visible');
+  });
+});


### PR DESCRIPTION
there was a bug in the audio service, expecting a previous audio object
to be present