### PR TITLE
Channel scripts

### DIFF
--- a/app/api-response/model.js
+++ b/app/api-response/model.js
@@ -24,6 +24,13 @@ export default DS.Model.extend({
       return 'story-detail';
     }
   }),
+  page: computed('contentType', function() {
+    if (['story-detail', 'about-page'].includes(this.get('contentType'))) {
+      return this.store.createRecord('django-page', {
+        text: this.get('aboutPage.escapedBody') || this.get('story.escapedBody')
+      });
+    }
+  }),
   totalCount: DS.attr('number'),
   totalPages: computed('totalCount', {
     get() {

--- a/app/channel/model.js
+++ b/app/channel/model.js
@@ -25,7 +25,8 @@ export default DS.Model.extend({
       }
       const chunk = chunks.compact().findBy('position', 'top');
       if (chunk) {
-        return chunk.content;
+        let text = chunk.content.replace(/\\x3C\/script>/g, '</script>');
+        return this.store.createRecord('django-page', { text });
       } else {
         return '';
       }
@@ -39,7 +40,8 @@ export default DS.Model.extend({
       }
       const chunk = chunks.compact().findBy('position', 'bottom');
       if (chunk) {
-        return chunk.content;
+        let text = chunk.content.replace(/\\x3C\/script>/g, '</script>');
+        return this.store.createRecord('django-page', { text });
       } else {
         return '';
       }

--- a/app/channel/template.hbs
+++ b/app/channel/template.hbs
@@ -74,11 +74,11 @@
             twitter=model.channel.twitter.firstObject
             newsletter=model.channel.newsletter.firstObject}}
 
-          {{{model.channel.chunkSidebarTop}}}
+          {{django-page page=model.channel.chunkSidebarTop loadingType='channel-page'}}
 
           {{google-ad ad="rightRail" class="align--mq-centertoright channel-ad"}}
 
-          {{{model.channel.chunkSidebarBottom}}}
+          {{django-page page=model.channel.chunkSidebarBottom loadingType='channel-page'}}
 
         </div>
         <!-- .l-skinny -->

--- a/app/channel/template.hbs
+++ b/app/channel/template.hbs
@@ -74,11 +74,15 @@
             twitter=model.channel.twitter.firstObject
             newsletter=model.channel.newsletter.firstObject}}
 
-          {{django-page page=model.channel.chunkSidebarTop loadingType='channel-page'}}
+          {{#if model.channel.chunkSidebarTop}}
+            {{django-page page=model.channel.chunkSidebarTop loadingType='channel-page'}}
+          {{/if}}
 
           {{google-ad ad="rightRail" class="align--mq-centertoright channel-ad"}}
 
-          {{django-page page=model.channel.chunkSidebarBottom loadingType='channel-page'}}
+          {{#if model.channel.chunkSidebarBottom}}
+            {{django-page page=model.channel.chunkSidebarBottom loadingType='channel-page'}}
+          {{/if}}
 
         </div>
         <!-- .l-skinny -->

--- a/app/components/about-page/template.hbs
+++ b/app/components/about-page/template.hbs
@@ -1,5 +1,5 @@
 <div class="text about-show" data-test-selector="about-page">
-  {{{ model.aboutPage.escapedBody }}}
+  {{django-page page=model.page loadingType='channel-page'}}
 </div>
 
 <section>

--- a/app/components/loading-templates/channel-page/template.hbs
+++ b/app/components/loading-templates/channel-page/template.hbs
@@ -1,0 +1,1 @@
+<div class="loading-page"></div>

--- a/app/components/loading-templates/component.js
+++ b/app/components/loading-templates/component.js
@@ -15,7 +15,7 @@ export default Component.extend({
     return `${type}-loading`;
   }),
   didRender() {
-    if (!Ember.testing) {
+    if (!Ember.testing && this.get('type') !== 'channel-page') {
       window.scrollTo(0, 0);
     }
   }

--- a/app/components/story-detail/template.hbs
+++ b/app/components/story-detail/template.hbs
@@ -1,3 +1,3 @@
 <div data-test-selector="story-detail" class="text">
-  {{{model.story.escapedBody}}}
+  {{django-page page=model.page loadingType='channel-page'}}
 </div>


### PR DESCRIPTION
This PR updates how channel sub-pages are rendered so that if any arbitrary javascript is found in the text, the web client will parse and properly execute them.

now, this opens us up to potential bad UX cases if our pages start adding event listeners from server-side JS. ember won't have a way to know if these things are piling up, but let's see how this works in the wild.