### PR TITLE
Staff Auth Compat

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -2,6 +2,7 @@ WNYC_URL=//dev.wnyc.net:MY_PORT
 WNYC_STATIC_URL=http://dev.wnyc.net:MY_PORT/static/
 WNYC_API=http://dev.wnyc.net:MY_PORT
 WNYC_ACCOUNT_ROOT=http://dev.wnyc.net:MY_PORT
+WNYC_ADMIN_ROOT=http://dev.wnyc.net:MY_PORT
 WNYC_ETAG_API=http://dev.wnyc.net:MY_PORT/api/v1/browser_id/
 WNYC_BETA_URL=http://dev.wnyc.net:MY_OTHER_PORT
 

--- a/app/channel/route.js
+++ b/app/channel/route.js
@@ -61,7 +61,7 @@ export default Route.extend(PlayParamMixin, {
       navRoot: get(this, 'listingSlug'),
       defaultSlug: navSlug,
       model,
-      isStaff: get(this, 'session.data.isStaff'),
+      session: get(this, 'session'),
       adminURL: config.wnycAccountRoot
     });
   },

--- a/app/channel/route.js
+++ b/app/channel/route.js
@@ -59,7 +59,9 @@ export default Route.extend(PlayParamMixin, {
       channelType: this.routeName,
       navRoot: get(this, 'listingSlug'),
       defaultSlug: navSlug,
-      model
+      model,
+      isStaff: get(this, 'session.data.isStaff'),
+      adminURL: config.wnycAccountRoot
     });
   },
   

--- a/app/channel/route.js
+++ b/app/channel/route.js
@@ -10,6 +10,7 @@ const { hash: waitFor } = Ember.RSVP;
 const inflector = new Inflector(Inflector.defaultRules);
 import { retryFromServer, beforeTeardown } from 'wnyc-web-client/lib/compat-hooks';
 import PlayParamMixin from 'wnyc-web-client/mixins/play-param';
+import config from 'wnyc-web-client/config/environment';
 
 export default Route.extend(PlayParamMixin, {
   session: service(),

--- a/app/channel/route.js
+++ b/app/channel/route.js
@@ -62,7 +62,7 @@ export default Route.extend(PlayParamMixin, {
       defaultSlug: navSlug,
       model,
       session: get(this, 'session'),
-      adminURL: config.wnycAccountRoot
+      adminURL: `${config.wnycAdminRoot}/admin`
     });
   },
   

--- a/app/channel/template.hbs
+++ b/app/channel/template.hbs
@@ -5,12 +5,12 @@
     {{/google-ad}}
 
     {{#if model.channel.hasMarquee}}
-      {{x-marquee model=model.channel isStaff=isStaff adminURL=adminURL}}
+      {{x-marquee model=model.channel isStaff=session.data.isStaff adminURL=adminURL}}
     {{else}}
       {{#if model.channel.featured}}
-        {{channel-header model=model.channel isStaff=isStaff adminURL=adminURL}}
+        {{channel-header model=model.channel isStaff=session.data.isStaff adminURL=adminURL}}
       {{else}}
-        {{channel-header model=model.channel isStaff=isStaff adminURL=adminURL classNames='flush'}}
+        {{channel-header model=model.channel isStaff=session.data.isStaff adminURL=adminURL classNames='flush'}}
       {{/if}}
     {{/if}}
 
@@ -22,7 +22,7 @@
           <h1 class="for-screenreaders">Featured Item</h1>
           {{story-tease
             parentTitle=model.channel.title
-            isStaff=isStaff
+            isStaff=session.data.isStaff
             adminURL=adminURL
             item=model.channel.featured
             hideLinks=true

--- a/app/channel/template.hbs
+++ b/app/channel/template.hbs
@@ -5,12 +5,12 @@
     {{/google-ad}}
 
     {{#if model.channel.hasMarquee}}
-      {{x-marquee model=model.channel user=model.user}}
+      {{x-marquee model=model.channel isStaff=isStaff adminURL=adminURL}}
     {{else}}
       {{#if model.channel.featured}}
-        {{channel-header model=model.channel user=model.user}}
+        {{channel-header model=model.channel isStaff=isStaff adminURL=adminURL}}
       {{else}}
-        {{channel-header model=model.channel user=model.user classNames='flush'}}
+        {{channel-header model=model.channel isStaff=isStaff adminURL=adminURL classNames='flush'}}
       {{/if}}
     {{/if}}
 
@@ -22,7 +22,8 @@
           <h1 class="for-screenreaders">Featured Item</h1>
           {{story-tease
             parentTitle=model.channel.title
-            user=model.user
+            isStaff=isStaff
+            adminURL=adminURL
             item=model.channel.featured
             hideLinks=true
             isFeatured=true

--- a/app/components/channel-header/template.hbs
+++ b/app/components/channel-header/template.hbs
@@ -30,8 +30,8 @@
     <!-- .l-col2of3 -->
 
     <div class="l-col1of3 l-col--flex l-col--cv l-col--right">
-      {{#if user.is_staff}}
-        <a href="{{user.adminURL}}/{{model.editLink}}" class="btn btn--green" style="margin:auto;" target="_blank" data-test-selector="admin-link">Edit this</a>
+      {{#if isStaff}}
+        <a href="{{adminURL}}/{{model.editLink}}" class="btn btn--green" style="margin:auto;" target="_blank" data-test-selector="admin-link">Edit this</a>
       {{/if}}
 
       {{#if model.hasHeaderButtons}}

--- a/app/components/comments-admin/component.js
+++ b/app/components/comments-admin/component.js
@@ -2,7 +2,7 @@ import Ember from 'ember';
 import ENV from 'wnyc-web-client/config/environment';
 
 export default Ember.Component.extend({
-  cmsUrl: ENV.wnycAccountRoot,
+  adminURL: `${ENV.wnycAdminRoot}/admin`,
   actions: {
     featureMe() {
       let id = this.get('id');

--- a/app/components/comments-admin/template.hbs
+++ b/app/components/comments-admin/template.hbs
@@ -2,4 +2,4 @@
 Featured!
 {{else}}
 <button {{action 'featureMe'}} class="js-feature-comment">Feature this Comment</button>{{/if}}
- | <a href="{{cmsUrl}}/admin/comments/wnyccomment/{{id}}" class="js-moderate-comment">Moderate</a>
+ | <a href="{{adminURL}}/comments/wnyccomment/{{id}}" class="js-moderate-comment">Moderate</a>

--- a/app/components/comments-form/component.js
+++ b/app/components/comments-form/component.js
@@ -26,7 +26,7 @@ export default Ember.Component.extend({
       'comment'
     ];
 
-    if ( !this.get('user.is_staff') ) {
+    if ( !this.get('isStaff') ) {
       requiredFields.push('email');
     }
 

--- a/app/components/comments-form/template.hbs
+++ b/app/components/comments-form/template.hbs
@@ -1,7 +1,7 @@
 <h2 class="h3 flush" id="commentsForm">Leave a comment</h2>
 <div class="text">Email addresses are required but never displayed</div>
 
-{{#unless user.is_staff}}
+{{#unless isStaff}}
 <fieldset class="fieldset">
     <label class="h4" for="name">Name</label>
     {{#if errors.name}}
@@ -32,7 +32,7 @@
     {{input value=location class="input flush" type="text" name="location"}}
 </fieldset>
 
-{{#if user.is_staff}}
+{{#if isStaff}}
 <fieldset class="fieldset">
     <label class="h4" for="userNameOverride">User name override</label>
     {{input value=nameOverride class="input flush" name="user_name_override"}}

--- a/app/components/comments-list/template.hbs
+++ b/app/components/comments-list/template.hbs
@@ -16,7 +16,7 @@
         <div class="l-split flush">
             <div class="dimmed">{{moment-format comment.publishDate 'MMM D, YYYY, h:mm A'}}</div>
 
-            {{#if user.is_staff}}
+            {{#if isStaff}}
                 {{comments-admin id=comment.id browserId=browserId}}
             {{/if}}
 

--- a/app/components/django-page/component.js
+++ b/app/components/django-page/component.js
@@ -9,6 +9,7 @@ import {
   embeddedComponentSetup,
   clearAlienDom,
 } from '../../lib/alien-dom';
+import config from 'wnyc-web-client/config/environment';
 
 const { get, computed, run } = Ember;
 let { wnycURL } = ENV;
@@ -85,6 +86,9 @@ export default Ember.Component.extend(LegacySupportMixin, BetaActionsMixin, {
           doRefresh();
         }
 
+        if (this.get('session.data.isStaff')) {
+          this.revealStaffLinks(this.$(), config.wnycAccountRoot);
+        }
         this.$().imagesLoaded().progress((i, image) => {
           Ember.run(() => {
             image.img.classList.add('is-loaded');

--- a/app/components/django-page/component.js
+++ b/app/components/django-page/component.js
@@ -9,10 +9,9 @@ import {
   embeddedComponentSetup,
   clearAlienDom,
 } from '../../lib/alien-dom';
-import config from 'wnyc-web-client/config/environment';
 
 const { get, computed, run } = Ember;
-let { wnycURL } = ENV;
+let { wnycURL, wnycAdminRoot, renderGoogleAds } = ENV;
 wnycURL = canonicalize(wnycURL);
 
 function doRefresh() {
@@ -82,12 +81,12 @@ export default Ember.Component.extend(LegacySupportMixin, BetaActionsMixin, {
         // re-enable any overlaid content so that it can wormhole
         // itself into the server-rendered DOM.
         this.set('showingOverlay', true);
-        if (ENV.renderGoogleAds) {
+        if (renderGoogleAds) {
           doRefresh();
         }
 
         if (this.get('session.data.isStaff')) {
-          this.revealStaffLinks(this.$(), config.wnycAccountRoot);
+          this.revealStaffLinks(this.$(), wnycAdminRoot);
         }
         this.$().imagesLoaded().progress((i, image) => {
           Ember.run(() => {

--- a/app/components/story-comments/template.hbs
+++ b/app/components/story-comments/template.hbs
@@ -18,11 +18,11 @@
     <div class="text">
         <a href="/feeds/comments/{{story.itemTypeId}}/{{story.id}}" target="_blank">RSS Feed for Comments</a> | <a href="#commentsForm">Leave a Comment</a>
     </div>
-    {{comments-list comments=comments user=user browserId=browserId}}
+    {{comments-list comments=comments isStaff=isStaff browserId=browserId}}
 {{/if}}
 
 {{#if isShowingForm}}
-    {{comments-form action='saveSuccess' user=user browserId=browserId story=story}}
+    {{comments-form action='saveSuccess' isStaff=isStaff browserId=browserId story=story}}
 
     <div class="text">
         <p>Please stay on topic, be civil, and be brief. By leaving a comment, you agree to our <a href="/privacy">Privacy Policy</a> and <a href="/terms/">Terms Of Use</a>.

--- a/app/components/story-list/component.js
+++ b/app/components/story-list/component.js
@@ -1,7 +1,9 @@
 import Component from 'ember-component';
 import service from 'ember-service/inject';
+import config from 'wnyc-web-client/config/environment';
 
 export default Component.extend({
   session: service(),
   tagName: 'section',
+  adminURL: config.wnycAccountRoot
 });

--- a/app/components/story-list/component.js
+++ b/app/components/story-list/component.js
@@ -5,5 +5,5 @@ import config from 'wnyc-web-client/config/environment';
 export default Component.extend({
   session: service(),
   tagName: 'section',
-  adminURL: config.wnycAccountRoot
+  adminURL: `${config.wnycAdminRoot}/admin`
 });

--- a/app/components/story-list/template.hbs
+++ b/app/components/story-list/template.hbs
@@ -3,7 +3,8 @@
   <li class="list-item">
     {{story-tease
       parentTitle=parentTitle
-      user=session.data.authenticated
+      isStaff=session.data.isStaff
+      adminURL=adminURL
       item=item
       playContext=playContext}}
   </li>

--- a/app/components/story-tease/template.hbs
+++ b/app/components/story-tease/template.hbs
@@ -68,8 +68,8 @@
         </div>
       {{/if}}
 
-      {{#if user.is_staff}}
-        <a href="{{user.adminURL}}/{{item.editLink}}" class="btn btn--green" target="_blank" data-test-selector="admin-link">Edit this</a>
+      {{#if isStaff}}
+        <a href="{{adminURL}}/{{item.editLink}}" class="btn btn--green" target="_blank" data-test-selector="admin-link">Edit this</a>
       {{/if}}
     </div>
     <!-- .btn-group -->

--- a/app/components/x-marquee/template.hbs
+++ b/app/components/x-marquee/template.hbs
@@ -2,5 +2,5 @@
   <div class="marquee-gradient" style={{marqueeGradientCSS}}></div>
 </div>
 <div class="marquee-footer">
-  {{channel-header model=model user=user}}
+  {{channel-header model=model isStaff=isStaff adminURL=adminURL}}
 </div>

--- a/app/metrics-adapters/data-warehouse.js
+++ b/app/metrics-adapters/data-warehouse.js
@@ -82,7 +82,7 @@ export default BaseAdapter.extend({
       endpoint: d.endpoint
     };
 
-    get(this, 'session').syncBrowserId(false).then(id => this._sendNow(options, id));
+    this._sendNow(options, get(this, 'session.data.browserId'));
   },
 
   willDestroy: K,

--- a/app/mixins/legacy-support.js
+++ b/app/mixins/legacy-support.js
@@ -30,7 +30,7 @@ export default Mixin.create({
       return legacy.queue(itemPK);
     }
   },
-  revealStaffLinks($element, adminURL) {
+  revealStaffLinks($element, adminRoot) {
     $element.find('.stf').each(function() {
       var $elt, $this = $(this);
       if (this.tagName.toLowerCase() === 'a') {
@@ -39,7 +39,7 @@ export default Mixin.create({
         $this.append($elt = $("<a/>").addClass(this.className));
       }
       $elt.html($elt.html() || 'Edit This').attr("target", '_blank');
-      $elt.attr("href", `${adminURL}/${$this.attr('data-url')}`);
+      $elt.attr("href", `${adminRoot}/admin/${$this.attr('data-url')}`);
       $this.show();
       $this.parent().show();
     });

--- a/app/mixins/legacy-support.js
+++ b/app/mixins/legacy-support.js
@@ -30,6 +30,20 @@ export default Mixin.create({
       return legacy.queue(itemPK);
     }
   },
+  revealStaffLinks($element, adminURL) {
+    $element.find('.stf').each(function() {
+      var $elt, $this = $(this);
+      if (this.tagName.toLowerCase() === 'a') {
+        $elt = $this;
+      } else {
+        $this.append($elt = $("<a/>").addClass(this.className));
+      }
+      $elt.html($elt.html() || 'Edit This').attr("target", '_blank');
+      $elt.attr("href", `${adminURL}/${$this.attr('data-url')}`);
+      $this.show();
+      $this.parent().show();
+    });
+  },
   actions: {
     listen(model, streamSlug) {
       const id = get(model, 'id');

--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -27,7 +27,7 @@ export default Route.extend(ApplicationRouteMixin, {
 
     let metrics = get(this, 'metrics');
 
-    this._syncBrowserId();
+    get(this, 'session').syncBrowserId();
     get(this, 'currentUser').load();
 
     metrics.identify('GoogleAnalytics', {isAuthenticated: false});
@@ -39,8 +39,7 @@ export default Route.extend(ApplicationRouteMixin, {
 
     window.WNYC_LEGACY_LOADER = get(this, 'legacyLoader');
 
-    let store = get(this, 'store');
-    let pollFunction = () => store.findAll('stream');
+    let pollFunction = () => get(this, 'store').findAll('stream');
     get(this, 'poll').addPoll({interval: 60 * 1000, callback: pollFunction});
   },
 
@@ -73,9 +72,5 @@ export default Route.extend(ApplicationRouteMixin, {
     this._super(...arguments);
     get(this, 'metrics').identify('GoogleAnalytics', {isAuthenticated: true});
     get(this, 'currentUser').load();
-  },
-
-  _syncBrowserId() {
-    return get(this, 'session').syncBrowserId();
   },
 });

--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -28,6 +28,7 @@ export default Route.extend(ApplicationRouteMixin, {
     let metrics = get(this, 'metrics');
 
     get(this, 'session').syncBrowserId();
+    get(this, 'session').staff();
     get(this, 'currentUser').load();
 
     metrics.identify('GoogleAnalytics', {isAuthenticated: false});

--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -28,7 +28,7 @@ export default Route.extend(ApplicationRouteMixin, {
     let metrics = get(this, 'metrics');
 
     get(this, 'session').syncBrowserId();
-    get(this, 'session').staff();
+    get(this, 'session').staffAuth();
     get(this, 'currentUser').load();
 
     metrics.identify('GoogleAnalytics', {isAuthenticated: false});

--- a/app/services/listen-actions.js
+++ b/app/services/listen-actions.js
@@ -6,7 +6,6 @@ export default Ember.Service.extend({
 
   init() {
     this.set('queue', []);
-    this.get('session').syncBrowserId(id => this.set('browserId', id));
   },
 
   sendPlay(pk, context) {
@@ -43,19 +42,16 @@ export default Ember.Service.extend({
       return;
     }
 
-    this.get('session').syncBrowserId(false).then(id => {
-      this.set('browserId', id);
 
-      if (queue.length === 1) {
-        let item = queue[0];
-        this._sendSingleListenAction(item.pk, item.action, item.context, item.value, item.ts);
-      }
-      else {
-        this._sendBulkListenActions(queue);
-      }
+    if (queue.length === 1) {
+      let item = queue[0];
+      this._sendSingleListenAction(item.pk, item.action, item.context, item.value, item.ts);
+    }
+    else {
+      this._sendBulkListenActions(queue);
+    }
 
-      this.set('queue', []);
-    });
+    this.set('queue', []);
   },
 
   _queueListenAction(pk, action, context, value) {
@@ -84,7 +80,7 @@ export default Ember.Service.extend({
     // ts:       Unixstyle epoch integer timestamp for when this event occured
 
     let baseUrl = [ENV.wnycAccountRoot, 'api/v1/listenaction/create', pk, action].join("/");
-    let url = `${baseUrl}/?browser_id=${this.get('browserId')}&context=${context}`;
+    let url = `${baseUrl}/?browser_id=${this.get('session.data.browserId')}&context=${context}`;
 
     return Ember.$.ajax({
       data: JSON.stringify({
@@ -114,7 +110,7 @@ export default Ember.Service.extend({
     let url = [ENV.wnycAccountRoot, 'api/v1/listenaction/create/'].join("/");
 
     let payload = {
-      browser_id: this.get('browserId'),
+      browser_id: this.get('session.data.browserId'),
       actions: data
     };
 

--- a/app/services/session.js
+++ b/app/services/session.js
@@ -1,6 +1,5 @@
 import SessionService from 'ember-simple-auth/services/session';
 import config from 'wnyc-web-client/config/environment';
-import RSVP from 'rsvp';
 import fetch from 'fetch';
 
 export default SessionService.extend({
@@ -11,12 +10,11 @@ export default SessionService.extend({
       if (report) {
         reportBrowserId(legacyId || browserId);
       }
-      return RSVP.Promise.resolve(legacyId || browserId)
-        .then(id => this.set('data.browserId', id));
+      this.set('data.browserId', legacyId || browserId);
+    } else {
+      getBrowserId()
+        .then( ({ browser_id }) => this.set('data.browserId', browser_id));
     }
-
-    return getBrowserId()
-      .then( ({ browser_id }) => this.set('data.browserId', browser_id));
   },
   
   staff() {
@@ -29,10 +27,9 @@ export default SessionService.extend({
 });
 
 function reportBrowserId(knownId) {
-  return fetch(config.wnycEtagAPI, {
+  fetch(config.wnycEtagAPI, {
     headers: { 'X-WNYC-BrowserId': knownId }
-  }).then(checkStatus)
-    .then(response => response.json());
+  });
 }
 
 function getBrowserId() {

--- a/app/services/session.js
+++ b/app/services/session.js
@@ -17,7 +17,7 @@ export default SessionService.extend({
     }
   },
   
-  staff() {
+  staffAuth() {
     fetch(`${config.wnycAdminRoot}/api/v1/is_logged_in/?bust_cache=${Math.random()}`, {
       credentials: 'include'
     })

--- a/app/services/session.js
+++ b/app/services/session.js
@@ -18,7 +18,7 @@ export default SessionService.extend({
   },
   
   staff() {
-    fetch(`${config.wnycAccountRoot}/api/v1/is_logged_in/?bust_cache=${Math.random()}`, {
+    fetch(`${config.wnycAdminRoot}/api/v1/is_logged_in/?bust_cache=${Math.random()}`, {
       credentials: 'include'
     })
     .then(checkStatus).then(r => r.json())

--- a/app/services/session.js
+++ b/app/services/session.js
@@ -17,6 +17,14 @@ export default SessionService.extend({
 
     return getBrowserId()
       .then( ({ browser_id }) => this.set('data.browserId', browser_id));
+  },
+  
+  staff() {
+    fetch(`${config.wnycAccountRoot}/api/v1/is_logged_in/?bust_cache=${Math.random()}`, {
+      credentials: 'include'
+    })
+    .then(checkStatus).then(r => r.json())
+    .then(({is_staff}) => this.set('data.isStaff', is_staff));
   }
 });
 

--- a/app/story/route.js
+++ b/app/story/route.js
@@ -8,10 +8,6 @@ const { hash: waitFor } = Ember.RSVP;
 export default Ember.Route.extend(PlayParamMixin, {
   metrics: service(),
   session: service(),
-  setupController(controller) {
-    controller.set('isMobile', window.Modernizr.touchevents);
-    return this._super(...arguments);
-  },
   titleToken(model) {
     return `${get(model, 'story.title')} - ${get(model, 'story.headers.brand.title')}`;
   },
@@ -57,6 +53,12 @@ export default Ember.Route.extend(PlayParamMixin, {
       nprVals,
       isNpr: true
     });
+  },
+  
+  setupController(controller) {
+    controller.set('isMobile', window.Modernizr.touchevents);
+    controller.set('session', get(this, 'session'));
+    return this._super(...arguments);
   },
   
   actions: {

--- a/app/story/route.js
+++ b/app/story/route.js
@@ -28,7 +28,7 @@ export default Ember.Route.extend(PlayParamMixin, {
         story,
         getComments: () => comments,
         getRelatedStories: () => relatedStories,
-        user: get(this, 'session.data.authenticated'),
+        isStaff: get(this, 'session.data.isStaff'),
         browserId: get(this, 'session.data.browserId')
       });
     });

--- a/app/story/template.hbs
+++ b/app/story/template.hbs
@@ -3,7 +3,7 @@
   {{#if model.story.commentsEnabled}}
     {{#ember-wormhole to="comments"}}
       {{story-comments story=model.story
-                       isStaff=model.isStaff
+                       isStaff=session.data.isStaff
                        getComments=model.getComments
                        browserId=model.browserId}}
     {{/ember-wormhole}}

--- a/app/story/template.hbs
+++ b/app/story/template.hbs
@@ -3,7 +3,7 @@
   {{#if model.story.commentsEnabled}}
     {{#ember-wormhole to="comments"}}
       {{story-comments story=model.story
-                       user=model.user
+                       isStaff=model.isStaff
                        getComments=model.getComments
                        browserId=model.browserId}}
     {{/ember-wormhole}}

--- a/circle.yml
+++ b/circle.yml
@@ -38,6 +38,7 @@ deployment:
             SENTRY_DSN: $PROD_SENTRY_EMBER_DSN
             SENTRY_PROJECT: $PROD_SENTRY_PROJECT
             SENTRY_EMBER_SOURCEMAPS_KEY: $PROD_SENTRY_EMBER_SOURCEMAPS_KEY
+            WNYC_ADMIN_ROOT: $PROD_ADMIN_ROOT
   demo:
     branch: demo
     commands:
@@ -56,6 +57,7 @@ deployment:
             SENTRY_PROJECT: $DEMO_SENTRY_PROJECT
             SENTRY_EMBER_SOURCEMAPS_KEY: $DEMO_SENTRY_EMBER_SOURCEMAPS_KEY
             AUTH_SERVICE: $DEMO_AUTH_SERVICE
+            WNYC_ADMIN_ROOT: $DEMO_ADMIN_ROOT
   auth:
     branch: auth
     commands:
@@ -74,6 +76,7 @@ deployment:
             SENTRY_PROJECT: $PROD_SENTRY_PROJECT
             SENTRY_EMBER_SOURCEMAPS_KEY: $PROD_SENTRY_EMBER_SOURCEMAPS_KEY
             AUTH_SERVICE: $DEMO_AUTH_SERVICE
+            WNYC_ADMIN_ROOT: $PROD_ADMIN_ROOT
 
 experimental:
   notify:

--- a/config/environment.js
+++ b/config/environment.js
@@ -98,6 +98,7 @@ module.exports = function(environment) {
     showsAPIKey: "hummingbird",
     moreShowsDiscoverStation: "archived-shows",
     moreShowsAPIKey: "mammoth",
+    wnycAdminRoot: process.env.WNYC_ADMIN_ROOT,
     wnycAuthAPI: process.env.AUTH_SERVICE,
     wnycAccountRoot: process.env.WNYC_ACCOUNT_ROOT,
     wnycEtagAPI: process.env.WNYC_ETAG_API,
@@ -168,6 +169,7 @@ module.exports = function(environment) {
 
     ENV.wnycAPI = 'http://example.com';
     ENV.wnycAccountRoot = 'http://example.com/account';
+    ENV.wnycAdminRoot = 'http://admin.example.com';
     ENV.wnycEtagAPI = 'http://example.com/api/v1/browser_id/';
     ENV.wnycStaticURL = 'http://example.com/static';
     ENV.wnycURL = '//example.com';

--- a/mirage/config.js
+++ b/mirage/config.js
@@ -95,11 +95,11 @@ export default function() {
   /*------------------------------------------------------------
     identity management (account) endpoints
   --------------------------------------------------------------*/
-  this.get(`${config.wnycAccountRoot}/api/v1/is_logged_in/`, {});
+  this.get(`${config.wnycAdminRoot}/api/v1/is_logged_in/`, {});
   this.get(`${config.wnycAccountRoot}/comments/security_info/`, {security_hash: 'foo', timestamp: Date.now()});
 
-  this.post(`${config.wnycAccountRoot}/api/v1/accounts/logout/`, {successful_logout: true});
-  this.post(`${config.wnycAccountRoot}/api/v1/accounts/login/`, function(schema, request) {
+  this.post(`${config.wnycAdminRoot}/api/v1/accounts/logout/`, {successful_logout: true});
+  this.post(`${config.wnycAdminRoot}/api/v1/accounts/login/`, function(schema, request) {
     let params = {};
     request.requestBody.split('&').forEach(p => {
       params[p.split('=')[0]] = p.split('=')[1];

--- a/mirage/config.js
+++ b/mirage/config.js
@@ -95,7 +95,7 @@ export default function() {
   /*------------------------------------------------------------
     identity management (account) endpoints
   --------------------------------------------------------------*/
-  this.get(`${config.wnycAccountRoot}/api/v1/is_logged_in/`, {isAuthenticated: true});
+  this.get(`${config.wnycAccountRoot}/api/v1/is_logged_in/`, {});
   this.get(`${config.wnycAccountRoot}/comments/security_info/`, {security_hash: 'foo', timestamp: Date.now()});
 
   this.post(`${config.wnycAccountRoot}/api/v1/accounts/logout/`, {successful_logout: true});

--- a/tests/acceptance/viewing-show-test.js
+++ b/tests/acceptance/viewing-show-test.js
@@ -40,7 +40,7 @@ test('smoke test', function(assert) {
 
 test('authenticated smoke test', function(assert) {
   server.create('user');
-  authenticateSession(this.application, {is_staff: true, access_token: 'foo'});
+  this.get(`${config.wnycAccountRoot}/api/v1/is_logged_in/`, {isStaff: true});
   let show = server.create('show', {
     id: 'shows/foo/',
     linkroll: [

--- a/tests/acceptance/viewing-show-test.js
+++ b/tests/acceptance/viewing-show-test.js
@@ -4,7 +4,6 @@ import djangoPage from 'wnyc-web-client/tests/pages/django-page';
 import showPage from 'wnyc-web-client/tests/pages/show';
 import { resetHTML } from 'wnyc-web-client/tests/helpers/html';
 import config from 'wnyc-web-client/config/environment';
-import { authenticateSession } from 'wnyc-web-client/tests/helpers/ember-simple-auth';
 
 moduleForAcceptance('Acceptance | Django Page | Show Page', {
   beforeEach() {
@@ -39,8 +38,8 @@ test('smoke test', function(assert) {
 });
 
 test('authenticated smoke test', function(assert) {
+  server.get(`${config.wnycAccountRoot}/api/v1/is_logged_in/`, {is_staff: true});
   server.create('user');
-  this.get(`${config.wnycAccountRoot}/api/v1/is_logged_in/`, {isStaff: true});
   let show = server.create('show', {
     id: 'shows/foo/',
     linkroll: [

--- a/tests/acceptance/viewing-show-test.js
+++ b/tests/acceptance/viewing-show-test.js
@@ -38,7 +38,7 @@ test('smoke test', function(assert) {
 });
 
 test('authenticated smoke test', function(assert) {
-  server.get(`${config.wnycAccountRoot}/api/v1/is_logged_in/`, {is_staff: true});
+  server.get(`${config.wnycAdminRoot}/api/v1/is_logged_in/`, {is_staff: true});
   server.create('user');
   let show = server.create('show', {
     id: 'shows/foo/',

--- a/tests/acceptance/viewing-story-test.js
+++ b/tests/acceptance/viewing-story-test.js
@@ -4,7 +4,6 @@ import djangoPage from 'wnyc-web-client/tests/pages/django-page';
 import storyPage from 'wnyc-web-client/tests/pages/story';
 import { resetHTML } from 'wnyc-web-client/tests/helpers/html';
 import config from 'wnyc-web-client/config/environment';
-import { authenticateSession } from 'wnyc-web-client/tests/helpers/ember-simple-auth';
 
 
 moduleForAcceptance('Acceptance | Django Page | Story Detail', {
@@ -46,8 +45,8 @@ test('view comments as regular user', function(assert) {
 });
 
 test('view comments as staff user', function(assert) {
+  server.get(`${config.wnycAccountRoot}/api/v1/is_logged_in/`, {is_staff: true});
   server.create('user');
-  authenticateSession(this.application, {is_staff: true, access_token: 'foo'});
   
   let story = server.create('story');
   let id = `story/${story.slug}/`;

--- a/tests/acceptance/viewing-story-test.js
+++ b/tests/acceptance/viewing-story-test.js
@@ -45,7 +45,7 @@ test('view comments as regular user', function(assert) {
 });
 
 test('view comments as staff user', function(assert) {
-  server.get(`${config.wnycAccountRoot}/api/v1/is_logged_in/`, {is_staff: true});
+  server.get(`${config.wnycAdminRoot}/api/v1/is_logged_in/`, {is_staff: true});
   server.create('user');
   
   let story = server.create('story');


### PR DESCRIPTION
[ticket](https://jira.wnyc.org/browse/WE-6689)

This adds a staff auth method to the session service so that users who have authenticated against the publisher admin can still see admin controls via the web client.

*note* this does not require the user to be authenticated cognito or the `currentUser` service. These are separate authentication systems and so they don't really relate to or rely upon one another.

This also includes some other small clean ups in code that was geographically nearby the code I was working on.