### PR TITLE
use an observer to validate emailConfirmation

### DIFF
--- a/app/components/account-signup-form/component.js
+++ b/app/components/account-signup-form/component.js
@@ -19,6 +19,7 @@ export default Component.extend({
     set(this, 'changeset', new Changeset(get(this, 'newUser'), lookupValidator(SignupValidations), SignupValidations));
     get(this, 'changeset').validate();
   },
+
   actions: {
     onSubmit() {
       return this.signUp();
@@ -31,6 +32,11 @@ export default Component.extend({
   },
   signUp() {
     return get(this, 'newUser').save();
+  },
+  onEmailInput() {
+    if (get(this, 'changeset.emailConfirmation')) {
+      get(this, 'changeset').validate('emailConfirmation');
+    }
   },
   applyErrorToChangeset(error, changeset) {
     if (error) {

--- a/app/components/account-signup-form/template.hbs
+++ b/app/components/account-signup-form/template.hbs
@@ -44,6 +44,7 @@
       value=changeset.email
       errors=changeset.error.email.validation
       submitted=form.status.tried
+      onInput=(action onEmailInput)
     }}
 
     {{nypr-input


### PR DESCRIPTION
[ticket](https://jira.wnyc.org/browse/WE-6700)
I don't love it, but emailConfirmation is not a field on the user model,
so there's no way to trigger the valiation on it unless we do it
manually. Or else we could refactor the templates to call a general
purpose "validate" method on input for all the inputs.

barring that, this is a way to run the validation on the confirm email
field whenever the email field value changes.