### PR TITLE
WE-6816 hide clue on valid password

### DIFF
--- a/app/components/account-reset-password-form/template.hbs
+++ b/app/components/account-reset-password-form/template.hbs
@@ -30,7 +30,7 @@
       value=changeset.password
       errors=changeset.error.password.validation
       submitted=form.status.tried
-      clue=(if changeset.error.password 'must be at least 8 characters and 1 number' '')
+      clue=(if changeset.error.password 'must be at least 8 characters and 1 number')
     }}
 
     <button type="submit" class="account-form-btn" disabled={{form.status.processing}}>Reset password</button>

--- a/app/components/account-reset-password-form/template.hbs
+++ b/app/components/account-reset-password-form/template.hbs
@@ -30,7 +30,7 @@
       value=changeset.password
       errors=changeset.error.password.validation
       submitted=form.status.tried
-      clue='must have at least 8 characters and one number'
+      clue=(if changeset.error.password 'must be at least 8 characters and 1 number' '')
     }}
 
     <button type="submit" class="account-form-btn" disabled={{form.status.processing}}>Reset password</button>

--- a/app/components/account-signup-form/template.hbs
+++ b/app/components/account-signup-form/template.hbs
@@ -62,7 +62,7 @@
       placeholder='enter a password'
       fieldname='typedPassword'
       value=changeset.typedPassword
-      clue='must be at least 8 characters and 1 number'
+      clue=(if changeset.error.typedPassword 'must be at least 8 characters and 1 number' '')
       errors=changeset.error.typedPassword.validation
       submitted=form.status.tried
     }}

--- a/app/components/account-signup-form/template.hbs
+++ b/app/components/account-signup-form/template.hbs
@@ -62,7 +62,7 @@
       placeholder='enter a password'
       fieldname='typedPassword'
       value=changeset.typedPassword
-      clue=(if changeset.error.typedPassword 'must be at least 8 characters and 1 number' '')
+      clue=(if changeset.error.typedPassword 'must be at least 8 characters and 1 number')
       errors=changeset.error.typedPassword.validation
       submitted=form.status.tried
     }}


### PR DESCRIPTION
Hide the password requirements once the user has typed a valid password.

https://jira.wnyc.org/browse/WE-6804