### PR TITLE
user disabled error messages for login and sign up

### DIFF
--- a/app/components/account-login-form/component.js
+++ b/app/components/account-login-form/component.js
@@ -6,6 +6,7 @@ import LoginValidations from 'wnyc-web-client/validations/login';
 import lookupValidator from 'ember-changeset-validations';
 import ENV from 'wnyc-web-client/config/environment';
 import service from 'ember-service/inject';
+import messages from 'wnyc-web-client/validations/custom-messages';
 
 export default Component.extend({
   resendEndpoint: `${ENV.wnycAuthAPI}/v1/confirm/resend`,
@@ -47,7 +48,10 @@ export default Component.extend({
   },
   applyErrorToChangeset(error, changeset) {
     if (error && error.code) {
-      if (error.code === "UnauthorizedAccess") {
+      changeset.rollback(); // so errors don't stack up
+      if (error.message === 'User is disabled') {
+        changeset.pushErrors('email', messages.userDisabled);
+      } else if (error.code === "UnauthorizedAccess") {
         changeset.validate('password');
         changeset.pushErrors('password', `There was a problem with the email and password for ${changeset.get('email')}. <a href="/signup">Sign up?</a>`);
       } else if (error.code === "UserNotFoundException") {

--- a/app/components/account-signup-form/component.js
+++ b/app/components/account-signup-form/component.js
@@ -8,6 +8,7 @@ import service from 'ember-service/inject';
 import ENV from 'wnyc-web-client/config/environment';
 import fetch from 'fetch';
 import { rejectUnsuccessfulResponses } from 'wnyc-web-client/utils/fetch-utils';
+import messages from 'wnyc-web-client/validations/custom-messages';
 
 export default Component.extend({
   store: service(),
@@ -33,9 +34,12 @@ export default Component.extend({
   },
   applyErrorToChangeset(error, changeset) {
     if (error) {
+      changeset.rollback(); // so errors don't stack up
       if (error.code === "AccountExists") {
         changeset.validate('email');
         changeset.pushErrors('email', `An account already exists for the email ${changeset.get('email')}.<br/> <a href="/login">Log in?</a> <a href="/forgot">Forgot password?</a>`);
+      } else if (error.message === 'User is disabled') {
+        changeset.pushErrors('email', messages.userDisabled);
       }
     }
   },

--- a/app/validations/custom-messages.js
+++ b/app/validations/custom-messages.js
@@ -9,4 +9,5 @@ export default {
   emailFormat:           'oops! looks like an invalid email address',
   emailConfirmation:     "oops! this email doesn't match the other one",
   passwordRules:         'must be at least 8 characters and 1 number',
+  userDisabled:          'This email is associated with a disabled account. If you would like to re-enable it, please contact listener services at <a href="http://www.wnyc.org/feedback" target="_blank">http://www.wnyc.org/feedback</a>.'
 };


### PR DESCRIPTION
adds new custom message and show it
also manually rollback changest to clear errors so they don't stack up

[ticket](https://jira.wnyc.org/browse/WE-6757)