### PR TITLE
use nypr-ui onInput event to validate email confirmation field

### DIFF
--- a/app/components/account-signup-form/component.js
+++ b/app/components/account-signup-form/component.js
@@ -19,6 +19,7 @@ export default Component.extend({
     set(this, 'changeset', new Changeset(get(this, 'newUser'), lookupValidator(SignupValidations), SignupValidations));
     get(this, 'changeset').validate();
   },
+
   actions: {
     onSubmit() {
       return this.signUp();
@@ -31,6 +32,11 @@ export default Component.extend({
   },
   signUp() {
     return get(this, 'newUser').save();
+  },
+  onEmailInput() {
+    if (get(this, 'changeset.emailConfirmation')) {
+      get(this, 'changeset').validate('emailConfirmation');
+    }
   },
   applyErrorToChangeset(error, changeset) {
     if (error) {

--- a/app/components/account-signup-form/template.hbs
+++ b/app/components/account-signup-form/template.hbs
@@ -44,6 +44,7 @@
       value=changeset.email
       errors=changeset.error.email.validation
       submitted=form.status.tried
+      onInput=(action onEmailInput)
     }}
 
     {{nypr-input


### PR DESCRIPTION
rebased version of the earlier PR