### PR TITLE
WE-6798 unclickable nav popout in discover

### DIFF
--- a/app/styles/_discover.scss
+++ b/app/styles/_discover.scss
@@ -37,6 +37,11 @@ body.ember-application.discover {
       top: 0;
       z-index: $zIndex--fixedNav;
       width: calc(100% - 150px); // side nav
+
+      .user-nav-link,
+      .user-nav-greeting {
+        color: white;
+      }
     }
   }
 

--- a/app/styles/_discover.scss
+++ b/app/styles/_discover.scss
@@ -38,9 +38,14 @@ body.ember-application.discover {
       z-index: $zIndex--fixedNav;
       width: calc(100% - 150px); // side nav
 
-      .user-nav-link,
       .user-nav-greeting {
         color: white;
+      }
+      .user-nav-link a {
+        color: white;
+        &:hover, &:focus {
+          color: rgba(white, .5);
+        }
       }
     }
   }

--- a/app/styles/_discover.scss
+++ b/app/styles/_discover.scss
@@ -35,7 +35,7 @@ body.ember-application.discover {
       @include transition(background-color $transition-timing);
       position: absolute;
       top: 0;
-      z-index: 1;
+      z-index: $zIndex--fixedNav;
       width: calc(100% - 150px); // side nav
     }
   }


### PR DESCRIPTION
changes the z-index of `.sitechrome-top` in discover, so the popup (a child of `.sitechrome-top`) can be higher.

Also updates the user nav link colors in discover because it was hard to read.

https://jira.wnyc.org/browse/WE-6798