### PR TITLE
WE-6837 Show new login error

### DIFF
--- a/app/components/account-login-form/template.hbs
+++ b/app/components/account-login-form/template.hbs
@@ -40,7 +40,11 @@
       helplinkText='Forgot Password?'
       submitted=form.status.tried
     }}
-
+    {{#if showLoginError}}
+      <div class='account-form-error'>
+        {{{messages.loginError}}}
+      </div>
+    {{/if}}
     <button type="submit" class="account-form-btn" disabled={{form.status.processing}}>Log in</button>
   {{/if}}
 {{/nypr-form}}

--- a/app/styles/_accounts.scss
+++ b/app/styles/_accounts.scss
@@ -47,7 +47,7 @@
 @include mq($medium-and-up, $h-medium-and-up) {
   .login {
     .account-form {
-      height: 470px;
+      height: 495px;
     }
 
     .account-promo {
@@ -236,6 +236,12 @@
     a {
       @include link--gray;
     }
+  }
+  &-error {
+    color: $red;
+    font-size: 12px;
+    text-align: center;
+    margin-bottom: 13px;
   }
 
   @include mq($middle-narrow-and-up) {

--- a/app/styles/_accounts.scss
+++ b/app/styles/_accounts.scss
@@ -242,6 +242,15 @@
     font-size: 12px;
     text-align: center;
     margin-bottom: 13px;
+    a {
+      color: $red;
+      border-bottom: 1px solid $red;
+    }
+    a:hover,
+    a:focus {
+      color: $rouge;
+      border-bottom: 1px solid $rouge;
+    }
   }
 
   @include mq($middle-narrow-and-up) {

--- a/app/validations/custom-messages.js
+++ b/app/validations/custom-messages.js
@@ -11,5 +11,7 @@ export default {
   emailFormat:           'oops! looks like an invalid email address',
   emailConfirmation:     "oops! this email doesn't match the other one",
   passwordRules:         'must be at least 8 characters and 1 number',
-  userDisabled:          'This email is associated with a disabled account. If you would like to re-enable it, please contact listener services at <a href="http://www.wnyc.org/feedback" target="_blank">http://www.wnyc.org/feedback</a>.'
+  userDisabled:          'This email is associated with a disabled account. If you would like to re-enable it, please contact listener services at <a href="http://www.wnyc.org/feedback" target="_blank">http://www.wnyc.org/feedback</a>.',
+  loginError:            "There's an error logging in.</br><a href='/forgot'>Forget your password</a>? Need to <a href='/signup'>create an account</a>?",
+  emailNotFound:         email => `We cannot find an account for the email ${email}. <a href="/signup">Sign up?</a>`
 };

--- a/tests/acceptance/login-test.js
+++ b/tests/acceptance/login-test.js
@@ -53,7 +53,7 @@ test('Submitting valid credentials redirects to previous route', function(assert
   });
 });
 
-test('Submitting invalid credentials shows error messages', function(assert) {
+test('Submitting invalid credentials shows form level error message', function(assert) {
   server.post(`${config.wnycAuthAPI}/v1/session`, () => {
     return new Response(400, {}, {errors: {code: "UnauthorizedAccess"}});
   });
@@ -67,7 +67,7 @@ test('Submitting invalid credentials shows error messages', function(assert) {
   andThen(() => {
     assert.equal(currentSession(this.application).get('isAuthenticated'), false);
     assert.equal(find('.account-form-heading').text().trim(), 'Log in to WNYC');
-    assert.equal(find('.nypr-input-error').length, 1);
+    assert.equal(find('.account-form-error').length, 1);
   });
 });
 


### PR DESCRIPTION
When there is an email/password mismatch, show the error separate from the input fields.

Also moves a few errors into custom-messages.

https://jira.wnyc.org/browse/WE-6837