### PR TITLE
Update Account and settings links to not refresh page.

### DIFF
--- a/app/components/user-navigation/component.js
+++ b/app/components/user-navigation/component.js
@@ -12,6 +12,15 @@ export default Component.extend({
         this.set('isPopupOpen', false);
       }
     },
+    closePopupAndTrack(title) {
+      this.get('metrics').trackEvent({
+        category: 'WNYC Menu',
+        label: `Clicked ${title}`,
+      });
+      if ( !(this.get('isDestroyed') || this.get('isDestroying')) ) {
+        this.set('isPopupOpen', false);
+      }
+    },
     togglePopup() {
       this.toggleProperty('isPopupOpen');
     },

--- a/app/components/user-navigation/template.hbs
+++ b/app/components/user-navigation/template.hbs
@@ -18,19 +18,11 @@
           </div>
           <div class="user-nav-popup">
             <ul class="user-nav-list">
-              <li class="user-nav-listitem">
-                <a href='/settings'
-                  title="Settings"
-                  data-tracking-category="WNYC Menu"
-                  data-tracking-action="Clicked Settings"
-                  onclick={{action 'closePopup'}}>Settings</a>
+              <li class="user-nav-listitem" {{action 'closePopupAndTrack' 'Settings'}}>
+                {{link-to 'Settings' 'settings'}}
               </li>
-              <li class="user-nav-listitem">
-                <a href='/profile'
-                  title="Account"
-                  data-tracking-category="WNYC Menu"
-                  data-tracking-action="Clicked Account"
-                  onclick={{action 'closePopup'}}>Account</a>
+              <li class="user-nav-listitem" {{action 'closePopupAndTrack' 'Account'}}>
+                {{link-to 'Account' 'profile'}}
               </li>
               <li class="user-nav-listitem"><a href="/" title="Log out" {{action 'logout'}}>Log out</a></li>
             </ul>


### PR DESCRIPTION
The tricky thing here is we can't use the link-handler to track
links from data-attributes AND have an action on the link to close
the popup.

Having an action manually fire the tracking event isn't super elegant,
but we can clean this up a little when we migrate the events to GTM.

https://jira.wnyc.org/browse/WE-7080