### PR TITLE
move class name tweaking to route

### DIFF
--- a/app/lib/compat-hooks.js
+++ b/app/lib/compat-hooks.js
@@ -79,12 +79,6 @@ export function beforeAppend(element, page) {
       legacyContent = element;
     }
     let newContent = document.createElement('div');
-    if (!$(legacyContent).hasClass('graphic-responsive')){
-      newContent.classList.add('l-constrained');
-    }
-    if (page.get('id') === 'search/') {
-      newContent.classList.add('search');
-    }
     while (legacyContent.firstChild) {
       newContent.appendChild(legacyContent.firstChild);
     }

--- a/app/routes/djangorendered.js
+++ b/app/routes/djangorendered.js
@@ -50,6 +50,19 @@ export default Route.extend(PlayParamMixin, {
       title
     });
   },
+  
+  setupController(controller, model) {
+    this._super(...arguments);
+    let doc = model.get('document');
+    let classNamesForRoute = [];
+    if (!doc.querySelector('.graphic-responsive')) {
+      classNamesForRoute.push('l-constrained');
+    }
+    if (model.get('id') === 'search/') {
+      classNamesForRoute.push('search');
+    }
+    controller.set('classNamesForRoute', classNamesForRoute);
+  },
 
   actions: {
     willTransition() {

--- a/app/templates/djangorendered.hbs
+++ b/app/templates/djangorendered.hbs
@@ -1,1 +1,1 @@
-{{django-page page=model}}
+{{django-page page=model classNames=classNamesForRoute}}

--- a/app/templates/index.hbs
+++ b/app/templates/index.hbs
@@ -1,4 +1,4 @@
-{{#django-page page=model.page}}
+{{#django-page page=model.page class='l-constrained'}}
 
   {{#if media.isSmallOnly}}
     {{#ember-wormhole to='stream-banner'}}

--- a/tests/acceptance/djangorendered-test.js
+++ b/tests/acceptance/djangorendered-test.js
@@ -128,6 +128,27 @@ test('.l-constrained is not added to responsive pages', function(assert) {
   });
 });
 
+test('.l-constrained is added to the home page', function(assert) {
+  let home = server.create('django-page', {
+    id: '/',
+    text: `
+    <div>
+      <div>
+    this is a regular template
+      </div>
+    </div>
+    `
+  });
+
+  djangoPage
+    .bootstrap(home)
+    .visit(home);
+
+  andThen(function() {
+    assert.equal(find('.django-content').parent('.l-constrained').length, 1, 'should have an l-constrained class');
+  });
+});
+
 test('.l-constrained is added to regular pages', function(assert) {
   let regularPage = server.create('django-page', {
     id: 'fake/',

--- a/tests/acceptance/djangorendered-test.js
+++ b/tests/acceptance/djangorendered-test.js
@@ -107,6 +107,60 @@ test('deferred scripts embedded within content do not run twice', function(asser
   });
 });
 
+test('.l-constrained is not added to responsive pages', function(assert) {
+  let responsivePage = server.create('django-page', {
+    id: 'fake/',
+    text: `
+    <div>
+      <div class="graphic-responsive">
+      this is a responsive template
+      </div>
+    </div>
+    `
+  });
+
+  djangoPage
+    .bootstrap(responsivePage)
+    .visit(responsivePage);
+
+  andThen(function() {
+    assert.equal(find('.django-content').parent('.l-constrained').length, 0, 'should not have an l-constrained class');
+  });
+});
+
+test('.l-constrained is added to regular pages', function(assert) {
+  let regularPage = server.create('django-page', {
+    id: 'fake/',
+    text: `
+    <div>
+      <div>
+    this is a regular template
+      </div>
+    </div>
+    `
+  });
+
+  djangoPage
+    .bootstrap(regularPage)
+    .visit(regularPage);
+
+  andThen(function() {
+    assert.equal(find('.django-content').parent('.l-constrained').length, 1, 'should have an l-constrained class');
+  });
+});
+
+test('.search is added to search pages', function(assert) {
+  let searchPage = server.create('django-page', { id: 'search/' });
+
+  djangoPage
+    .bootstrap(searchPage)
+    .visit(searchPage);
+
+  andThen(function() {
+    assert.equal(find('.django-content').parent('.search').length, 1, 'should have an l-constrained class');
+  });
+});
+
 moduleForAcceptance('Acceptance | Django Rendered | Beta Trial', {
   beforeEach() {
     server.create('stream');

--- a/tests/acceptance/viewing-show-test.js
+++ b/tests/acceptance/viewing-show-test.js
@@ -114,7 +114,7 @@ test('scripts in well route content will execute', function(assert) {
 
   var p = document.createElement("p");
   p.innerHTML = "Added this paragraph!";
-  document.querySelector("[data-test-selector=story-detail] .l-constrained").appendChild(p);
+  document.querySelector("[data-test-selector=story-detail] .django-content").appendChild(p);
 
 })();
 \\x3C/script>
@@ -143,7 +143,7 @@ test('scripts in well route content will execute', function(assert) {
 
   andThen(function() {
     assert.equal(find('[data-test-selector=story-detail] p').length, 1, 'should only be one p tag');
-    let text = find('[data-test-selector=story-detail] .l-constrained').text().split('\n').filter(s => s).join(' ');
+    let text = find('[data-test-selector=story-detail] .django-content').find('p, div').text().split('\n').filter(s => s).join(' ');
     assert.equal(text, 'test body. Added this paragraph!');
   });
 });


### PR DESCRIPTION
django pages have become useful for rendering UI components as well as
route-level "page" objects. This PR moves class tweaking to the
`djangorendered` route so that inappropriate classes aren't added to page
UI objects. This will prevent `.l-constrained` from being added to `django-page` components rendered at a deeper nested position.