### PR TITLE
Fix mobile header for studio 360

### DIFF
--- a/app/styles/_site-chrome.scss
+++ b/app/styles/_site-chrome.scss
@@ -47,7 +47,7 @@
   ));
   @include mq($small-only) {
     @include flexbox((
-      justify-content: space-between,
+      justify-content: flex-end,
       flex-wrap: wrap
     ));
   }


### PR DESCRIPTION
Some shows use a more explicit donate button so we want to make sure no matter what donate button they use, the header looks good. https://jira.wnyc.org/browse/WE-7111