### PR TITLE
WE-7083 control auth routes access

### DIFF
--- a/app/controllers/reset.js
+++ b/app/controllers/reset.js
@@ -1,7 +1,11 @@
 import Controller from 'ember-controller';
+import service from 'ember-service/inject';
+import config from 'wnyc-web-client/config/environment';
 
 export default Controller.extend({
+  session: service(),
   queryParams: ['confirmation', 'email'],
   confirmation: null,
-  email: null
+  email: null,
+  config,
 });

--- a/app/controllers/validate.js
+++ b/app/controllers/validate.js
@@ -1,7 +1,11 @@
 import Controller from 'ember-controller';
+import config from 'wnyc-web-client/config/environment';
+import service from 'ember-service/inject';
 
 export default Controller.extend({
+  session: service(),
   queryParams: ['confirmation', 'username'],
   confirmation: null,
-  username: null
+  username: null,
+  config,
 });

--- a/app/mixins/deauthenticated-route-mixin.js
+++ b/app/mixins/deauthenticated-route-mixin.js
@@ -1,0 +1,26 @@
+import Ember from 'ember';
+import service from 'ember-service/inject';
+import set from 'ember-metal/set';
+import get from 'ember-metal/get';
+
+// Invalidates an authenticated session,
+// but sets a flag to not refresh the page.
+//
+// This is for routes where the user is presented
+// with a login form after some sort of token check
+// such as /validate, and /reset
+//
+// The user should be logged out so they can log in with their own account,
+// but we still want to stay on the route.
+export default Ember.Mixin.create({
+  session: service(),
+
+  beforeModel() {
+    if (get(this, 'session.isAuthenticated')) {
+      // we check for the noRefresh flag on
+      // sessionInvalidated() on the application route
+      set(this, 'session.noRefresh', true);
+      get(this, 'session').invalidate();
+    }
+  }
+});

--- a/app/mixins/deauthenticated-route-mixin.js
+++ b/app/mixins/deauthenticated-route-mixin.js
@@ -22,5 +22,6 @@ export default Ember.Mixin.create({
       set(this, 'session.noRefresh', true);
       get(this, 'session').invalidate();
     }
+    this._super(...arguments);
   }
 });

--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -75,4 +75,12 @@ export default Route.extend(ApplicationRouteMixin, {
     get(this, 'metrics').identify('GoogleAnalytics', {isAuthenticated: true});
     get(this, 'currentUser').load();
   },
+
+  sessionInvalidated() {
+    if (this.get('session.noRefresh') === true) {
+      this.set('session.noRefresh', false);
+    } else {
+      this._super(...arguments);
+    }
+  }
 });

--- a/app/routes/login.js
+++ b/app/routes/login.js
@@ -1,8 +1,9 @@
 import Ember from 'ember';
 import service from 'ember-service/inject';
 import config from 'wnyc-web-client/config/environment';
+import UnauthenticatedRouteMixin from 'ember-simple-auth/mixins/unauthenticated-route-mixin';
 
-export default Ember.Route.extend({
+export default Ember.Route.extend(UnauthenticatedRouteMixin, {
   config,
   session: service(),
   titleToken: 'Log in',

--- a/app/routes/reset.js
+++ b/app/routes/reset.js
@@ -1,21 +1,15 @@
 import Route from 'ember-route';
-import service from 'ember-service/inject';
-import config from 'wnyc-web-client/config/environment';
+import DeauthenticatedRouteMixin from 'wnyc-web-client/mixins/deauthenticated-route-mixin';
 
-export default Route.extend({
-  config,
-  session: service(),
-  setupController(controller) {
-    controller.set('config', this.get('config'));
-    controller.set('session', this.get('session'));
-    return this._super(...arguments);
-  },
+export default Route.extend(DeauthenticatedRouteMixin, {
   beforeModel(transition) {
     if ( !transition.queryParams.email || !transition.queryParams.confirmation ) {
       // if we got here with missing url parameters,
       // (i.e. typing url, bad copy/paste)
       // send the user to the 'forgot' page so they can request a reset email
       this.transitionTo('forgot');
+    } else {
+      this._super(...arguments);
     }
   },
   actions: {

--- a/app/routes/signup.js
+++ b/app/routes/signup.js
@@ -1,8 +1,9 @@
 import Route from 'ember-route';
 import service from 'ember-service/inject';
 import config from 'wnyc-web-client/config/environment';
+import UnauthenticatedRouteMixin from 'ember-simple-auth/mixins/unauthenticated-route-mixin';
 
-export default Route.extend({
+export default Route.extend(UnauthenticatedRouteMixin, {
   config,
   session: service(),
   setupController(controller) {

--- a/app/routes/validate.js
+++ b/app/routes/validate.js
@@ -1,15 +1,7 @@
 import Route from 'ember-route';
-import service from 'ember-service/inject';
-import config from 'wnyc-web-client/config/environment';
+import DeauthenticatedRouteMixin from 'wnyc-web-client/mixins/deauthenticated-route-mixin';
 
-export default Route.extend({
-  config,
-  session: service(),
-  setupController(controller) {
-    controller.set('config', this.get('config'));
-    controller.set('session', this.get('session'));
-    return this._super(...arguments);
-  },
+export default Route.extend(DeauthenticatedRouteMixin, {
   actions: {
     didTransition() {
       this.send('disableChrome');

--- a/app/services/session.js
+++ b/app/services/session.js
@@ -51,8 +51,7 @@ export default SessionService.extend({
   verify(email, password) {
     let authenticator = getOwner(this).lookup('authenticator:nypr');
     return authenticator.authenticate(email, password);
-  }
-
+  },
 });
 
 function reportBrowserId(knownId) {

--- a/tests/acceptance/login-test.js
+++ b/tests/acceptance/login-test.js
@@ -3,7 +3,7 @@ import djangoPage from 'wnyc-web-client/tests/pages/django-page';
 import moduleForAcceptance from 'wnyc-web-client/tests/helpers/module-for-acceptance';
 import { Response } from 'ember-cli-mirage';
 import config from 'wnyc-web-client/config/environment';
-import { currentSession } from 'wnyc-web-client/tests/helpers/ember-simple-auth';
+import { authenticateSession, currentSession } from 'wnyc-web-client/tests/helpers/ember-simple-auth';
 import 'wnyc-web-client/tests/helpers/with-feature';
 import dummySuccessProviderFb from 'wnyc-web-client/tests/helpers/torii-dummy-success-provider-fb';
 import dummyFailureProvider from 'wnyc-web-client/tests/helpers/torii-dummy-failure-provider';
@@ -20,6 +20,17 @@ test('visiting /login', function(assert) {
 
   andThen(() => {
     assert.equal(currentURL(), '/login');
+  });
+});
+
+test("can't visit /login when authenticated", function(assert) {
+  server.create('user');
+  authenticateSession(this.application, {access_token: 'foo'});
+
+  visit('/login');
+
+  andThen(() => {
+    assert.equal(currentURL(), '/');
   });
 });
 

--- a/tests/acceptance/reset-test.js
+++ b/tests/acceptance/reset-test.js
@@ -2,7 +2,7 @@ import { test } from 'qunit';
 import moduleForAcceptance from 'wnyc-web-client/tests/helpers/module-for-acceptance';
 import { Response } from 'ember-cli-mirage';
 import config from 'wnyc-web-client/config/environment';
-import { currentSession } from 'wnyc-web-client/tests/helpers/ember-simple-auth';
+import { authenticateSession, currentSession } from 'wnyc-web-client/tests/helpers/ember-simple-auth';
 
 moduleForAcceptance('Acceptance | reset');
 
@@ -18,6 +18,18 @@ test('visiting /reset with no params', function(assert) {
 
   andThen(() => {
     assert.equal(currentURL(), '/forgot', 'it should redirect to forgot password page if you go to /reset with no params');
+  });
+});
+
+test('visiting /reset deauthenticates but remains on page', function(assert) {
+  server.create('user');
+  authenticateSession(this.application, {access_token: 'foo'});
+
+  visit(resetUrlWithEmailAndConfirmation);
+
+  return andThen(() => {
+    assert.notOk(currentSession(this.application).get('isAuthenticated'));
+    assert.equal(currentURL(), resetUrlWithEmailAndConfirmation);
   });
 });
 
@@ -63,6 +75,33 @@ test('visiting /reset and resetting password and logging in', function(assert) {
   });
 });
 
+test('visiting /reset and resetting password and logging in still works when starting logged in', function(assert) {
+  server.create('user');
+  authenticateSession(this.application, {access_token: 'foo'});
+
+  visit(resetUrlWithEmailAndConfirmation);
+
+  andThen(() => {
+    assert.equal(currentURL(), resetUrlWithEmailAndConfirmation);
+    assert.equal(find('.account-form-heading').text().trim(), 'Reset your password', 'it should show the reset password form');
+  });
+
+  fillIn('input[name=password]', password);
+  click('button:contains(Reset password)');
+
+  andThen(() => {
+    assert.equal(find('.account-form-heading').text().trim(), 'Log in to WNYC', 'it should show a login form when you click reset password with a good email code and password');
+  });
+
+  fillIn('input[name=email]', email);
+  fillIn('input[name=password]', password);
+
+  click('button[type=submit]:contains(Log in)');
+
+  andThen(() => {
+    assert.ok(currentSession(this.application).get('isAuthenticated'));
+  });
+});
 
 test('visiting /reset and getting a server error when submitting the form', function(assert) {
   server.post(`${config.wnycAuthAPI}/v1/confirm/password-reset`, () => {

--- a/tests/acceptance/reset-test.js
+++ b/tests/acceptance/reset-test.js
@@ -50,6 +50,7 @@ test('visiting /reset with a bad code', function(assert) {
 });
 
 test('visiting /reset and resetting password and logging in', function(assert) {
+  server.create('stream');
   server.create('user');
   visit(resetUrlWithEmailAndConfirmation);
 
@@ -76,6 +77,7 @@ test('visiting /reset and resetting password and logging in', function(assert) {
 });
 
 test('visiting /reset and resetting password and logging in still works when starting logged in', function(assert) {
+  server.create('stream');
   server.create('user');
   authenticateSession(this.application, {access_token: 'foo'});
 

--- a/tests/acceptance/signup-test.js
+++ b/tests/acceptance/signup-test.js
@@ -1,7 +1,7 @@
 import { test } from 'qunit';
 import moduleForAcceptance from 'wnyc-web-client/tests/helpers/module-for-acceptance';
 import 'wnyc-web-client/tests/helpers/with-feature';
-import { currentSession } from 'wnyc-web-client/tests/helpers/ember-simple-auth';
+import { authenticateSession, currentSession } from 'wnyc-web-client/tests/helpers/ember-simple-auth';
 import dummySuccessProviderFb from 'wnyc-web-client/tests/helpers/torii-dummy-success-provider-fb';
 import dummyFailureProvider from 'wnyc-web-client/tests/helpers/torii-dummy-failure-provider';
 import { registerMockOnInstance } from 'wnyc-web-client/tests/helpers/register-mock';
@@ -17,6 +17,17 @@ test('visiting /signup', function(assert) {
 
   andThen(() => {
     assert.equal(currentURL(), '/signup');
+  });
+});
+
+test("can't visit /signup when authenticated", function(assert) {
+  server.create('user');
+  authenticateSession(this.application, {access_token: 'foo'});
+
+  visit('/signup');
+
+  andThen(() => {
+    assert.equal(currentURL(), '/');
   });
 });
 

--- a/tests/acceptance/validate-test.js
+++ b/tests/acceptance/validate-test.js
@@ -1,6 +1,6 @@
 import { test } from 'qunit';
 import moduleForAcceptance from 'wnyc-web-client/tests/helpers/module-for-acceptance';
-import { currentSession } from 'wnyc-web-client/tests/helpers/ember-simple-auth';
+import { authenticateSession, currentSession } from 'wnyc-web-client/tests/helpers/ember-simple-auth';
 // import { Response } from 'ember-cli-mirage';
 // import config from 'wnyc-web-client/config/environment';
 
@@ -12,6 +12,17 @@ test('visiting /validate with no params', function(assert) {
   return andThen(() => {
     assert.equal(currentURL(), '/validate');
     assert.equal(find('h2').text().trim(), 'Oops!');
+  });
+});
+
+test('visiting /validate deauthenticates but remains on page', function(assert) {
+  server.create('user');
+  authenticateSession(this.application, {access_token: 'foo'});
+  visit('/validate');
+
+  return andThen(() => {
+    assert.notOk(currentSession(this.application).get('isAuthenticated'));
+    assert.equal(currentURL(), '/validate');
   });
 });
 
@@ -33,3 +44,25 @@ test('visiting /validate and logging in', function(assert) {
     assert.ok(currentSession(this.application).get('isAuthenticated'));
   });
 });
+
+test('visiting /validate and logging in even when starting logged in', function(assert) {
+  server.create('user');
+  authenticateSession(this.application, {access_token: 'foo'});
+
+  visit('/validate?username=test&confirmation=123');
+
+  andThen(() => {
+    assert.equal(currentURL(), '/validate?username=test&confirmation=123');
+    assert.equal(find('.alert-success').text().trim(), 'Your email has been verified and your online account is now active.');
+    assert.equal(find('h2').text().trim(), 'Log in to WNYC');
+  });
+
+  fillIn('input[name=email]', 'user@example.com');
+  fillIn('input[name=password]', 'password1');
+  click('button[type=submit]:contains(Log in)');
+
+  return andThen(() => {
+    assert.ok(currentSession(this.application).get('isAuthenticated'));
+  });
+});
+

--- a/tests/acceptance/validate-test.js
+++ b/tests/acceptance/validate-test.js
@@ -27,6 +27,7 @@ test('visiting /validate deauthenticates but remains on page', function(assert) 
 });
 
 test('visiting /validate and logging in', function(assert) {
+  server.create('stream');
   server.create('user');
   visit('/validate?username=test&confirmation=123');
 
@@ -46,6 +47,7 @@ test('visiting /validate and logging in', function(assert) {
 });
 
 test('visiting /validate and logging in even when starting logged in', function(assert) {
+  server.create('stream');
   server.create('user');
   authenticateSession(this.application, {access_token: 'foo'});
 

--- a/tests/acceptance/verify-test.js
+++ b/tests/acceptance/verify-test.js
@@ -2,7 +2,11 @@ import { test } from 'qunit';
 import moduleForAcceptance from 'wnyc-web-client/tests/helpers/module-for-acceptance';
 import { authenticateSession } from 'wnyc-web-client/tests/helpers/ember-simple-auth';
 
-moduleForAcceptance('Acceptance | verify');
+moduleForAcceptance('Acceptance | verify', {
+  beforeEach() {
+    server.create('stream');
+  }
+});
 
 test('visiting /verify unauthenticated shows a login form', function(assert) {
   visit('/verify');

--- a/tests/unit/mixins/deauthenticated-route-mixin-test.js
+++ b/tests/unit/mixins/deauthenticated-route-mixin-test.js
@@ -1,0 +1,12 @@
+import Ember from 'ember';
+import DeauthenticatedRouteMixinMixin from 'wnyc-web-client/mixins/deauthenticated-route-mixin';
+import { module, test } from 'qunit';
+
+module('Unit | Mixin | deauthenticated route mixin');
+
+// Replace this with your real tests.
+test('it works', function(assert) {
+  let DeauthenticatedRouteMixinObject = Ember.Object.extend(DeauthenticatedRouteMixinMixin);
+  let subject = DeauthenticatedRouteMixinObject.create();
+  assert.ok(subject);
+});


### PR DESCRIPTION
#### Sets /login and /signup to unauthenticated routes. 
You can only visit them while unauthenticated
If you attempt to visit while authenticated, you are redirected to the index.

#### Sets /reset and /validate to "deauthenticated" routes.
If you visit these routes while authenticated, you will become unauthenticated, but remain on the route.
These routes present the user with a login form after they come in from an email, so on the off chance a user clicks a link in their email while already logged in (maybe even to a different account) we want to log them out so they can log in properly when the login form appears.

(We could be nicer and log the user out here closer to when they try to log in but I think this is rare enough that we can use a blunt tool and log them out when the route loads. And being able to using a mixin to manage this like the other types of routes is nice.)