### PR TITLE
wnyc social icons header override

### DIFF
--- a/app/styles/_site-chrome.scss
+++ b/app/styles/_site-chrome.scss
@@ -379,6 +379,15 @@
   @include l-bottom;
   @include player-reveal-transition;
   @include player-reveal-transition--closed;
+
+  .nypr-social-icons__header{
+    color: $darkestgray;
+  }
+  .nav--homepage & {
+    .nypr-social-icons__header {
+      color: white;
+    }
+  }
 }
 
 .sitechrome--player-open .sitechrome__nav-footer {


### PR DESCRIPTION
This addresses changing the white "Follow" header in the site chrome to gray on the inner pages.