### PR TITLE
Dasherize keys

### DIFF
--- a/app/api-response/serializer.js
+++ b/app/api-response/serializer.js
@@ -1,6 +1,17 @@
 import DS from 'ember-data';
 
 export default DS.JSONAPISerializer.extend({
-  keyForRelationship: key => key,
-  keyForAttribute: key => key
+  normalizeResponse(store, typeClass, payload, id, requestType) {
+    payload.included = payload.included || [];
+    payload.included = payload.included.map(r => {
+      let { attributes, type, id, relationships } = r;
+      // story serializer expects keys dasherized
+      let attrs = {};
+      if (attributes) {
+        Object.keys(attributes).forEach(k => attrs[k.dasherize()] = attributes[k]);
+      }
+      return {type, id, attributes: attrs, relationships};
+    });
+    return this._super(store, typeClass, payload, id, requestType);
+  }
 });

--- a/app/api-response/serializer.js
+++ b/app/api-response/serializer.js
@@ -1,7 +1,6 @@
 import DS from 'ember-data';
 
 export default DS.JSONAPISerializer.extend({
-  keyForRelationship(key) { return key; },
-  keyForAttribute(key) { return key; }
+  keyForRelationship: key => key,
+  keyForAttribute: key => key
 });
-

--- a/app/bucket/serializer.js
+++ b/app/bucket/serializer.js
@@ -1,9 +1,16 @@
 import JSONAPISerializer from 'ember-data/serializers/json-api';
 
 export default JSONAPISerializer.extend({
-  keyForAttribute(key) { return key; },
+  extractId: (modelClass, {attributes}) => attributes.slug,
   normalizeResponse(store, klass, payload/*, id, requestType*/) {
-    payload.data.id = payload.data.attributes.slug;
+    // these are not actual ember models; need to camelize for consumption by components
+    payload.data.attributes['bucket-items'].forEach(item => {
+      let { attributes } = item;
+      item.attributes = {};
+  
+      Object.keys(attributes)
+        .forEach(k => item.attributes[k.camelize()] = attributes[k]);
+    });
     return this._super(...arguments);
   }
 });

--- a/app/channel/serializer.js
+++ b/app/channel/serializer.js
@@ -3,7 +3,7 @@ import DS from 'ember-data';
 export default DS.JSONAPISerializer.extend({
   keyForAttribute: key => key,
   keyForRelationship: key => key,
-  normalizeResponse(store, typeClass, payload, id) {
+  normalizeResponse(store, typeClass, payload, id, requestType) {
     let featuredStory = payload.data.attributes.featured;
     delete payload.data.attributes.featured;
     payload.included = payload.included || [];
@@ -39,7 +39,6 @@ export default DS.JSONAPISerializer.extend({
         }
       };
     }
-    return payload;
+    return this._super(store, typeClass, payload, id, requestType);
   }
 });
-

--- a/app/channel/serializer.js
+++ b/app/channel/serializer.js
@@ -1,6 +1,8 @@
 import DS from 'ember-data';
 
 export default DS.JSONAPISerializer.extend({
+  keyForAttribute: key => key,
+  keyForRelationship: key => key,
   normalizeResponse(store, typeClass, payload, id) {
     let featuredStory = payload.data.attributes.featured;
     delete payload.data.attributes.featured;

--- a/app/chunk/serializer.js
+++ b/app/chunk/serializer.js
@@ -1,7 +1,5 @@
 import JSONAPISerializer from 'ember-data/serializers/json-api';
 
 export default JSONAPISerializer.extend({
-  extractId(modelClass, {attributes}) {
-    return attributes.slug;
-  }
+  extractId: (modelClass, {attributes}) => attributes.slug,
 });

--- a/app/models/django-page.js
+++ b/app/models/django-page.js
@@ -42,7 +42,9 @@ export default DS.Model.extend({
     if (json) {
       let storySerializer = this.store.serializerFor('story');
       let storyModel = this.store.modelFor('story');
-      let { id } = json.data;
+      let { id, attributes } = json.data;
+      json.data.attributes = {};
+      Object.keys(attributes).forEach(k => json.data.attributes[k.dasherize()] = attributes[k]);
       return this.store.push(storySerializer.normalizeSingleResponse(this.store, storyModel, json, id));
     }
   }),

--- a/app/models/django-page.js
+++ b/app/models/django-page.js
@@ -61,7 +61,7 @@ export default DS.Model.extend({
         json = JSON.parse(channel.textContent);
       } catch(err) {}
       if (json) {
-        return this.store.push(channelSerializer.normalizeResponse(this.store, channelModel, json, id));
+        return this.store.push(channelSerializer.normalizeResponse(this.store, channelModel, json, id, 'findRecord'));
       }
     }
   }),

--- a/app/shows/serializer.js
+++ b/app/shows/serializer.js
@@ -1,7 +1,6 @@
 import JSONAPISerializer from 'ember-data/serializers/json-api';
 
 export default JSONAPISerializer.extend({
-  keyForAttribute: (key) => key,
   modelNameFromPayloadKey() {
     return 'shows';
   }

--- a/app/story/model.js
+++ b/app/story/model.js
@@ -24,7 +24,10 @@ export default Model.extend({
   dateLineDatetime: attr('string'),
   editLink: attr('string'),
   headers: attr(),
-  imageMain: attr(),
+  // TODO: make this a relationship when stories come in only over /api/v3
+  // right now they're still consumed from HTML and as part of listing pages
+  // imageMain: DS.belongsTo('image'),
+  imageMain: DS.attr(),
   itemType: attr('string'),
   itemTypeId: attr('number'),
   isLatest: attr('boolean'),

--- a/app/story/serializer.js
+++ b/app/story/serializer.js
@@ -1,8 +1,6 @@
 import DS from 'ember-data';
 
 export default DS.JSONAPISerializer.extend({
-  keyForAttribute(key) { return key; },
-  payloadKeyFromModelName() { return 'story'; },
   normalizeQueryResponse(store, primaryModelClass, payload, id, requestType) {
     let transformed = {
       data: payload.results.map(result => {

--- a/mirage/serializers/api-response.js
+++ b/mirage/serializers/api-response.js
@@ -1,6 +1,6 @@
-import ApplicationSerializer from './application';
+import { JSONAPISerializer } from 'ember-cli-mirage';
 
-export default ApplicationSerializer.extend({
+export default JSONAPISerializer.extend({
+  typeKeyForModel: ({ modelName }) => modelName.dasherize(),
   include: ['teaseList', 'story']
 });
-

--- a/mirage/serializers/application.js
+++ b/mirage/serializers/application.js
@@ -1,20 +1,4 @@
 import { JSONAPISerializer } from 'ember-cli-mirage';
-import Ember from 'ember';
-const { dasherize } = Ember.String;
 
 export default JSONAPISerializer.extend({
-  typeKeyForModel({ modelName }) {
-    return dasherize(modelName);
-  },
-
-  // Our API generally uses camelCased keys instead of dasherized-keys
-  // so we need to override these attribute hooks.
-
-  keyForAttribute(attribute) {
-    return attribute;
-  },
-
-  keyForRelationship(relationship) {
-    return relationship;
-  }
 });

--- a/mirage/serializers/bucket.js
+++ b/mirage/serializers/bucket.js
@@ -1,8 +1,6 @@
 import { JSONAPISerializer } from 'ember-cli-mirage';
 
 export default JSONAPISerializer.extend({
-  // our keys are already camelized
-  keyForAttribute: attr => attr,
   serialize(response, request) {
     // if a request has a query string, mirage thinks it's a request for multiple
     // records, but buckets use a query string as a back-end filter

--- a/mirage/serializers/django-page.js
+++ b/mirage/serializers/django-page.js
@@ -1,4 +1,4 @@
-import { Serializer  } from 'ember-cli-mirage';
+import { Serializer } from 'ember-cli-mirage';
 
 export default Serializer.extend({
   // we're actually returning HTML from our server, so we can't have a rootKey

--- a/mirage/serializers/order.js
+++ b/mirage/serializers/order.js
@@ -1,9 +1,0 @@
-import { JSONAPISerializer } from 'ember-cli-mirage';
-import Ember from 'ember';
-const { dasherize } = Ember.String;
-
-export default JSONAPISerializer.extend({
-  keyForAttribute(attribute) {
-    return dasherize(attribute);
-  },
-});

--- a/mirage/serializers/show.js
+++ b/mirage/serializers/show.js
@@ -3,6 +3,7 @@ import { dasherize } from 'ember-string';
 
 export default ApplicationSerializer.extend({
   include: ['apiResponse'],
+  keyForAttribute: key => key,
   keyForRelationship: key => dasherize(key),
   typeKeyForModel(model) {
     // This is a Mirage serialization bug, the wrong serializer
@@ -10,7 +11,7 @@ export default ApplicationSerializer.extend({
     if (model.modelName === 'show') {
       return 'channel';
     } else {
-      return ApplicationSerializer.prototype.typeKeyForModel(model);
+      return model.modelName.dasherize();
     }
   },
 });

--- a/mirage/serializers/story.js
+++ b/mirage/serializers/story.js
@@ -1,8 +1,8 @@
-import Serializer from './application';
+import { JSONAPISerializer } from 'ember-cli-mirage';
 
-export default Serializer.extend({
+export default JSONAPISerializer.extend({
   serialize(response, request) {
-    let story = Serializer.prototype.serialize.apply(this, arguments);
+    let story = JSONAPISerializer.prototype.serialize.apply(this, arguments);
     if (request && request.url.match('related')) {
       return {
         results: story.data.map(({id, attributes}) => Object.assign({id}, attributes))

--- a/mirage/serializers/user.js
+++ b/mirage/serializers/user.js
@@ -1,0 +1,5 @@
+import { JSONAPISerializer } from 'ember-cli-mirage';
+
+export default JSONAPISerializer.extend({
+  keyForAttribute: key => key.underscore()
+});


### PR DESCRIPTION
This PR brings the web client into line with the conventional `dasherized-keys` used in the JSON:API spec.

A few notes:
* the `api-response` is an abstract model used on listing pages to represent an arbitrary result from a query saved in publisher using a `Linkroll` model. The records sideloaded in the `included` array can anything; ideally this would have full support as a polymorphic model, but we're not there yet. For now, we're taking the dasherized keys output from the server and transforming them to camelCase, to be consumed as regular JSON objects by the rest of the app.
* `bucket` models are the same way: the `bucketItems` attribute should really be polymorphic, but we're not set up, so just camelCase the keys
* `channel` models are weird, because they're built "by hand" (i.e. not using DRF), so the sideloaded records all have camel cased keys. Some keys have been dasherized on the server, such as the `api-response` attributes, but sideloaded stories need their keys dasherized in the serializer.
* stories that are manually serialized on listing pages also need to dasherized

This PR is a client-side requirement for nypublicradio/publisher#122 