### PR TITLE
Add xml report output in circle ci to test config

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -17,7 +17,7 @@ jobs:
           key: grunt-and-bower
           paths:
             - ~/.config/yarn/global
-      
+
       - restore_cache:
           key: bower-deps-{{ checksum "bower.json" }}
       - run:
@@ -62,7 +62,11 @@ jobs:
           key: modernizr-{{ .Revision }}
       - run:
           name: Test
+          environment:
+            CIRCLE_TEST_REPORTS: test-results
           command: ./node_modules/ember-cli/bin/ember test
+      - store_test_results:
+          path: test-results/
 
   deploy:
     docker:

--- a/testem.js
+++ b/testem.js
@@ -19,7 +19,6 @@ module.exports = {
   launch_in_ci: [
     'Chrome'
   ],
-<<<<<<< HEAD
   launch_in_dev: [
     'Firefox',
     'Chrome'

--- a/testem.js
+++ b/testem.js
@@ -1,10 +1,25 @@
-/* eslint-env node */
+/*jshint node:true*/
+function reportFile() {
+  if (_circleTestFolder()) {
+    return _circleTestFolder() + '/test.xml';
+  }
+}
+
+function testReporter() {
+  return _circleTestFolder() ? 'xunit' : 'tap';
+}
+
+function _circleTestFolder() {
+  return process.env['CIRCLE_TEST_REPORTS'];
+}
+
 module.exports = {
   test_page: 'tests/index.html?hidepassed',
   disable_watching: true,
   launch_in_ci: [
     'Chrome'
   ],
+<<<<<<< HEAD
   launch_in_dev: [
     'Firefox',
     'Chrome'
@@ -16,5 +31,12 @@ module.exports = {
       '--remote-debugging-port=9222',
       '--window-size=1440,900'
     ]
-  }
+  },
+  "launch_in_dev": [
+    "Chrome",
+    "Firefox"
+  ],
+  "reporter": testReporter(),
+  "report_file": reportFile(),
+  "xunit_intermediate_output": true
 };


### PR DESCRIPTION
Enables this tab in the Circle CI build page:

![screen shot 2017-06-26 at 11 11 33 am](https://user-images.githubusercontent.com/6074785/27546349-85010288-5a60-11e7-8c1a-5f499cae15cd.png)
https://circleci.com/gh/nypublicradio/wnyc-web-client/1686

Also adds an .xml test report with individual test timings to the circle artifacts folders.

Local testing should remain unaffected by this change.