### PR TITLE
match wqxr playlist page

### DIFF
--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -88,6 +88,7 @@ body:not(.simplified_wrapper):not(.container_stripped) {
 @import 'legacy/search';
 @import 'legacy/screen';
 @import 'legacy/schedule';
+@import 'legacy/musicians-ensemble';
 @import 'legacy/nav-menu';
 @import 'legacy/user-profile';
 @import 'legacy/footer';

--- a/app/styles/legacy/_musicians-ensemble.scss
+++ b/app/styles/legacy/_musicians-ensemble.scss
@@ -1,0 +1,86 @@
+.musician-detail {
+  .playlist-tease {
+    border-bottom: none;
+
+    .playlist-entry {
+      /* "last played", record label and length */
+      h5,
+      .catalog_entry-catno {
+        font-size: 12px;
+        font-weight: 600;
+      }
+      /* piece title */
+      h2 {
+        font-family: "Lato", sans-serif;
+      }
+
+      .piece-info ul,
+      ul.playlist-actions {
+        list-style: none;
+        padding-left: 0;
+      }
+
+    }
+  }
+
+}
+
+.playlist-item {
+  padding-left: 50px !important;
+  @include flexbox((
+    display: flex,
+    flex-direction: column
+  ));
+  border-bottom: 0 !important;
+  padding-bottom: 0 !important;
+
+  &:first-child {
+    border-top: 1px dotted $line--light;
+  }
+
+  .playlist-info {
+      width: auto !important;
+  }
+
+  &__composer,
+  &__special-programming {
+    @include link--dark;
+    @include fontsize(18);
+    font-weight: 600;
+  }
+
+  &__title {
+    @include fontsize(16);
+  }
+
+  &__musicians {
+    color: $lightgray;
+  }
+
+  .time {
+    font-size: 14px !important;
+    color: $lightgray !important;
+    font-weight: 600 !important;
+    margin: 0 !important;
+    text-align: left !important;
+  }
+
+  .piece-info {
+    @include fontsize(16);
+    line-height: 27px;
+    color: $darkergray !important;
+
+    ul {
+      padding: 0;
+      margin: 0 !important;
+    }
+
+    li {
+      list-style: none;
+    }
+  }
+
+  .album-info .playlist-actions {
+    margin: 3px 0 0 0;
+  }
+}

--- a/app/styles/legacy/_schedule.scss
+++ b/app/styles/legacy/_schedule.scss
@@ -1,64 +1,126 @@
+
 .scheduled-item-link,
 .program .tease {
   display: none;
 }
 
 .print-schedule a {
-	margin: -78px 5px 0 0 !important;
-  color: $gray;
-  font-size: 12px;
-  
+	margin: -96px 5px 0 0 !important;
+  color: $lightgray;
+  font-weight: 600;
+  border: 0;
+
   &:hover {
     color: $blue;
   }
 }
 
-.station-nav {
+
+#daily-schedule .station-nav {
   margin-top: 10px;
   height: auto !important;
   border: none !important;
-  
-  ul.schedule-tabs li a {    
-    font-weight: 600;
+  margin-bottom: 20px;
+
+  ul.schedule-tabs {
+    width: 100%;
+    overflow-x: scroll;
+    white-space: nowrap;
+    -webkit-overflow-scrolling: touch;
+    border-bottom: 1px solid $line--light;
+    @include flexbox((
+      display: flex
+    ));
+
+    li a {
+      font-weight: 600;
+      @include fontsize(16);
+      padding: 0 0 30px 0;
+      margin: 0 25px 0 0;
+
+      @include mq($mobile) {
+        padding-bottom: 40px;
+        margin: 0 15px 0 0;
+      }
+    }
+
+    li:last-child a {
+      margin: 0;
+    }
+    /* hide the scrollbar, but keep it scrollable */
+    &::-webkit-scrollbar { 
+      display: none; 
+    }
   }
-  
+  ul.schedule-tabs li.ui-tabs-selected a {
+    color: $blue;
+    border-bottom: 3px solid $blue;
+    background: white;
+  }
+
   ul.schedule-tabs li:not(.ui-tabs-selected) a {
     color: $lightgray !important;
-    
+
     &:hover {
-      color: $red !important;
+      color: $blue !important;
     }
   }
 }
 
 ul.schedule-dates {
-  border-top: 1px solid $nearwhite;
-  border-bottom: 1px solid $nearwhite;
-  padding: 10px 0 5px 0 !important;
-    
+  padding: 10px 0 10px 0 !important;
+  width: auto !important;
+  background-color: $graywhite;
+
+  li.today {
+    letter-spacing: 0 !important;
+    text-transform: none !important;
+    font-weight: 600 !important;
+    flex: 2;
+
+    .h2 {
+      margin: 0;
+    }
+
+    > div {
+      color: $lightgray;
+    }
+  }
+
+  @include flexbox((
+    display: flex,
+    flex-wrap: wrap,
+    justify-content: space-between,
+    align-items: center
+  ));
+
   li.yesterday,
   li.tomorrow {
-    width: auto !important;
-    
+    flex: 1;
+
     a {
-      font-size: 12px !important;
-      letter-spacing: 2px;
-      text-transform: uppercase;
-      font-weight: 700 !important;       
+      font-size: 16px !important;
+      font-weight: 600 !important;
+      color: $lightgray;
+
+      &:hover {
+        color: $blue;
+      }
     }
-    
+
     a:hover,
     a:hover path {
       color: $blue;
       fill: $blue;
       border-color: white;
-    }    
+    }
   }
-  
+
   .action-button-icon {
     display: inline;
     position: relative;
     top: 2px;
+    padding: 0;
 
     svg {
       width: 20px;
@@ -68,16 +130,16 @@ ul.schedule-dates {
       }
     }
   }
-} 
-   
+}
+
 ul.schedule-table {
-  margin: 5px 0 0 0;
-  
+  margin: 5px 0 30px 0;
+
   .event {
     border-bottom: 1px solid $nearwhite;
     padding: 20px 0;
   }
-  
+
   li.head {
     font-size: 16px;
     font-weight: normal;
@@ -88,39 +150,54 @@ ul.schedule-table {
     height: auto;
     padding: 0;
     line-height: 27px;
-    
+    @include flexbox((
+      display: flex,
+      flex-direction: column,
+      align-items: flex-start
+    ));
+
     div.program {
       height: auto;
-      
+      @include h3;
+      font-family: "Open Sans";
+
       a {
-        font-size: 12px;
-        letter-spacing: 2px;
-        text-transform: uppercase;
-        color: #333;
-        font-weight: 700;
-        
-        &:hover {
-          color: $blue;
-        }  
+        @include link--dark;
       }
     }
-    
-    div.time {
-      color: $lightergray;
-      font-weight: 600;
-      letter-spacing: 1px;
+
+    div.expand {
+      display: none;
     }
-    
+
+    div.time,
+    div.time-playlist {
+      width: auto;
+      color: $lightgray;
+      font-weight: 600;
+      @include fontsize(14);
+    }
+
+    div.scheduled-item-shortlink a {
+      @include h3;
+      font-family: "Open Sans";
+      @include link--dark;
+    }
+
     .arrow {
       display: none;
     }
-    
-  }
-  
 
-  li.details { 
+    .options {
+      display: none;
+    }
+
+  }
+
+
+  li.details {
     display: list-item !important;
-    
+
     .text {
       font-size: 16px;
       margin-bottom: (1.25 / 2) * 1rem;
@@ -129,15 +206,27 @@ ul.schedule-table {
         margin-bottom: (1.25 / 2) * 1rem;
       }
     }
-    
+
+    .event {
+      border: none;
+
+      .played-list .playlist-item:last-child {
+        border-bottom: none;
+      }
+
+      .played-list .playlist-item ul.playlist-actions {
+        padding-left: 0;
+      }
+    }
+
     .program {
       border: none;
       padding: 0;
-      
+
       .image {
         display: none;
       }
-      
+
       .text {
         float: left;
         margin: 0 0 0 105px;
@@ -149,68 +238,73 @@ ul.schedule-table {
   ul.hosts {
     display: none;
   }
+
 }
+
+.schedule-table li.head div.playlist-social {
+  display: none;
+}
+
+
 
 @include mq($medium-only) {
   .schedule-playlists,
-  ul.schedule-dates, 
+  ul.schedule-dates,
   #site {
     width: 100% !important;
     overflow: hidden;
   }
-  
+
   .main.schedule-playlists {
     margin: 0 0 100px 0;
   }
-  
+
   .grid_8 {
     width: 100% !important;
     margin: 0 !important;
   }
-  
+
   .print-schedule {
     display: none;
   }
-  
+
   ul.schedule-table li.details .program .text {
       margin: 0;
   }
-  
+
   .site-container .grid_4 {
     display: none;
   }
-  
+
   ul.schedule-dates {
     display: flex;
     flex-flow: row wrap;
-    justify-content: space-between; 
+    justify-content: space-between;
     padding: 10px 0;
-    
-    li.yesterday,
-    li.tomorrow,
-    li.today {
-      width: auto !important;
-      padding-left: 0;
-      padding-right: 0;
-    }  
   }
-}  
+}
 
 @include mq($small-only) {
+  .schedule-table li.details .playlist-item h4,
+  .schedule-table li.details .playlist-item h3 {
+    width: auto !important;
+    float: none !important;
+  }
+
   ul.schedule-dates {
     li.yesterday a span,
     li.tomorrow a span {
       display: none;
     }
-    
+
     li.today {
       text-transform: none !important;
       letter-spacing: 0 !important;
     }
-    
+
     .action-button-icon {
       top: 0;
-      
+
       svg {
         width: 26px;
         height: 26px;
@@ -221,5 +315,5 @@ ul.schedule-table {
       }
     }
   }
-  
+
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5910,7 +5910,7 @@ nypr-player@nypublicradio/nypr-player:
 
 nypr-ui@nypublicradio/nypr-ui:
   version "0.0.0"
-  resolved "https://codeload.github.com/nypublicradio/nypr-ui/tar.gz/759910695347335dd738aeaf89cfb2f60c462c88"
+  resolved "https://codeload.github.com/nypublicradio/nypr-ui/tar.gz/e8fa75a950377687c7e6076f5425cfaf2985cd9f"
   dependencies:
     ember-basic-dropdown "0.33.1"
     ember-cli-babel "^6.6.0"


### PR DESCRIPTION
[WE-7470](https://jira.wnyc.org/browse/WE-7470)

This copies over the `musicians-ensemble` and `schedule` sass partials from the wqxr web client.

It also bumps the hash for nypr-ui. I moved some sass mixins to a different file so we can start moving towards the idea that nypr-ui doesn't produce CSS but rather exposes SASS variables for upstream apps to use.