### PR TITLE
use /v4/make_playlist

### DIFF
--- a/app/discover/stories/adapter.js
+++ b/app/discover/stories/adapter.js
@@ -9,7 +9,7 @@ const path = featureFlags['other-discover'] ? 'reco_proxy' : 'make_playlist';
 export default DS.JSONAPIAdapter.extend(DataAdapterMixin, {
   authorizer: 'authorizer:nypr',
   host: ENV.wnycAPI,
-  namespace: `api/v3/${path}/`,
+  namespace: `api/v4/${path}/`,
   session: service(),
 
   buildURL() {

--- a/mirage/config.js
+++ b/mirage/config.js
@@ -75,7 +75,7 @@ export default function() {
   this.get(`${baseUrl}/api/v3/chunks/:id/`, 'chunk');
 
   let discoverPath = config.featureFlags['other-discover'] ? 'reco_proxy' : 'make_playlist';
-  this.get(`${config.wnycAPI}/api/v3/${discoverPath}`, function(schema) {
+  this.get(`${config.wnycAPI}/api/v4/${discoverPath}`, function(schema) {
     let stories = schema.discoverStories.all().models;
 
     let data = stories.map(s => {

--- a/tests/acceptance/discover-returning-user-test.js
+++ b/tests/acceptance/discover-returning-user-test.js
@@ -175,7 +175,7 @@ test('if find more returns no more items, the old queue is present and an error 
     assert.equal($(".discover-playlist-no-results").length, 0, "playlist no results error area should not be visible");
 
     andThen(function() {
-      let url = [ENV.wnycAPI, 'api/v3', discoverPath].join("/");
+      let url = [ENV.wnycAPI, 'api/v4', discoverPath].join("/");
       server.get(url, function() {
         secondRequestCalled = true;
         let data = server.db.discoverStories.map(s => {
@@ -224,7 +224,7 @@ test('if find more returns the same list of items, the old queue are displayed a
     assert.equal($(".discover-playlist-no-results").length, 0, "playlist no results error area should not be visible");
 
     andThen(function() {
-      let url = [ENV.wnycAPI, 'api/v3', discoverPath].join("/");
+      let url = [ENV.wnycAPI, 'api/v4', discoverPath].join("/");
       server.get(url, function() {
         secondRequestCalled = true;
         return {data: []};
@@ -265,7 +265,7 @@ test('if find more returns new items, the new items are displayed', function(ass
     assert.ok((matchResults.length === 1) && (matchResults[0] === true), "Should have matched all the stories in the db");
     assert.equal($(".discover-playlist-no-results").length, 0, "playlist no results error area should not be visible");
 
-    let url = [ENV.wnycAPI, 'api/v3', discoverPath].join("/");
+    let url = [ENV.wnycAPI, 'api/v4', discoverPath].join("/");
 
     let stories = server.createList('discover-story', 5);
 

--- a/tests/acceptance/discover-test.js
+++ b/tests/acceptance/discover-test.js
@@ -328,7 +328,7 @@ skip('playlist request sends stories and tags in correct format', function(asser
           andThen(() => {
             click($('button:contains("Create Playlist")'));
             //
-            let url =[ENV.wnycAPI, 'api/v3/make_playlist'].join("/");
+            let url =[ENV.wnycAPI, 'api/v4/make_playlist'].join("/");
 
             server.get(url, function(schema, request) {
 


### PR DESCRIPTION
We need to change v3 on the backend to use camelCased keys.
I'm setting up v4 to keep the current kebab-cased jsonapi keys.
see also: https://github.com/nypublicradio/publisher/pull/133