### PR TITLE
WE-7525 save #fb-root from being cleared away by alien dom cleanups

### DIFF
--- a/app/lib/alien-dom.js
+++ b/app/lib/alien-dom.js
@@ -20,7 +20,7 @@ export function isInDom(id) {
 // of an Alien DOM. This will run on every django-page render, but should be a simple
 // no-op after one run.
 export function clearAlienDom() {
-  let nodesToRemove = document.querySelectorAll(config.alienDom.keepInDom);
+  let nodesToRemove = document.querySelectorAll(config.alienDom.toRemove);
   
   Array.from(nodesToRemove).forEach((n) => {
     n.parentNode.removeChild(n);

--- a/app/lib/alien-dom.js
+++ b/app/lib/alien-dom.js
@@ -20,10 +20,9 @@ export function isInDom(id) {
 // of an Alien DOM. This will run on every django-page render, but should be a simple
 // no-op after one run.
 export function clearAlienDom() {
-  let root = config.environment === 'test' ? '#ember-testing' : 'body';
-  let notEmber = document.querySelectorAll(`${root} > :not(.ember-view), ${root} > head > link[rel=stylesheet]:not([href*=assets])`);
+  let nodesToRemove = document.querySelectorAll(config.alienDom.keepInDom);
   
-  Array.from(notEmber).forEach((n) => {
+  Array.from(nodesToRemove).forEach((n) => {
     n.parentNode.removeChild(n);
   });
 }

--- a/config/environment.js
+++ b/config/environment.js
@@ -163,7 +163,7 @@ module.exports = function(environment) {
       }
     },
     alienDom: {
-      keepInDom: `${ALIEN_DOM_ROOT} > :not(.ember-view, #fb-root), ${ALIEN_DOM_ROOT} > head > link[rel=stylesheet]:not([href*=assets])`
+      keepInDom: `${ALIEN_DOM_ROOT} > :not(.ember-view):not(#fb-root), ${ALIEN_DOM_ROOT} > head > link[rel=stylesheet]:not([href*=assets])`
     }
   };
 

--- a/config/environment.js
+++ b/config/environment.js
@@ -8,6 +8,8 @@ module.exports = function(environment) {
       return arg.indexOf('--proxy') === 0;
     }).length;
   }
+  
+  const ALIEN_DOM_ROOT = environment === 'test' ? '#ember-testing' : 'body';
 
   let ENV = {
     modulePrefix: 'wnyc-web-client',
@@ -159,6 +161,9 @@ module.exports = function(environment) {
           version: 'v2.8'
         }
       }
+    },
+    alienDom: {
+      keepInDom: `${ALIEN_DOM_ROOT} > :not(.ember-view, #fb-root), ${ALIEN_DOM_ROOT} > head > link[rel=stylesheet]:not([href*=assets])`
     }
   };
 

--- a/config/environment.js
+++ b/config/environment.js
@@ -163,7 +163,7 @@ module.exports = function(environment) {
       }
     },
     alienDom: {
-      keepInDom: `${ALIEN_DOM_ROOT} > :not(.ember-view):not(#fb-root), ${ALIEN_DOM_ROOT} > head > link[rel=stylesheet]:not([href*=assets])`
+      toRemove: `${ALIEN_DOM_ROOT} > :not(.ember-view):not(#fb-root), ${ALIEN_DOM_ROOT} > head > link[rel=stylesheet]:not([href*=assets])`
     }
   };
 


### PR DESCRIPTION
[WE-7525](https://jira.wnyc.org/browse/WE-7525)

also makes the selector configurable so this file can be shared as an
addon