### PR TITLE
GT-85 news show titles

### DIFF
--- a/app/controllers/application.js
+++ b/app/controllers/application.js
@@ -43,13 +43,10 @@ export default Controller.extend({
       this._wasModal = true;
     },
 
-    trackStreamData() {
-      /* TODO: This still feels weird to have this action called by
-        the component's didUpdateAttrs hook. Seems like we could
-        watch, nay, *observe* the showTitle and call this on change
-      */
-
-      this.get('listenAnalytics').trackStreamData(this.get('hifi.currentSound'));
+    soundTitleDidChange() {
+      if (this.get('hifi.currentSound.isStream')) {
+        this.get('listenAnalytics').trackStreamData(this.get('hifi.currentSound'));
+      }
     },
 
     trackShare(data, sharedFrom) {

--- a/app/story/template.hbs
+++ b/app/story/template.hbs
@@ -33,7 +33,7 @@
                     playContext="story-header"
                     itemPK=model.story.slug
                     itemTitle=model.story.title
-                    itemShow=model.story.showTitle}}
+                    itemShow=(or model.story.showTitle model.story.headers.brand.title)}}
                     Listen <span class="text--small dimmed">{{model.story.audioDurationReadable}}</span>
                   {{/listen-button}}
                   {{queue-button
@@ -71,7 +71,7 @@
                     playContext="story-list"
                     itemPK=row.segment.slug
                     itemTitle=row.segment.title
-                    itemShow=model.story.showTitle
+                    itemShow=(or model.story.showTitle model.story.headers.brand.title)
                     type="blue-circle"}}
                   {{queue-button
                     itemPK=row.segment.slug

--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -69,7 +69,7 @@
             audioId         = integration.currentAudioId
             songDetails     = integration.songDetails
             isStream        = integration.isStream
-            trackStreamData = (action 'trackStreamData')
+            titleDidChange  = (action 'soundTitleDidChange')
           }}
 
           {{#unless hifi.isLoading}} {{! only show the share button when the audio has loaded}}


### PR DESCRIPTION
https://jira.wnyc.org/browse/GT-85
> - For WNYC News stories, the show name appears in the label on the "Pause" event but not on the "Played Story" event

For `listen-button` instances, we need to set `itemShow` to `headers.brand.title` when `showTitle` is not available, so that "WNYC News" is added to the button's `data-show` attribute where we can use it for GTM events.