### PR TITLE
Updates to circle 2.0

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -32,7 +32,7 @@ jobs:
           key: node-deps-{{ checksum "yarn.lock" }}
       - run:
           name: Node dependencies
-          command: yarn
+          command: yarn --pure-lockfile
       - save_cache:
           key: node-deps-{{ checksum "yarn.lock" }}
           paths:

--- a/circle.yml
+++ b/circle.yml
@@ -80,12 +80,12 @@ jobs:
       - run:
           name: Deploy to S3 and Redis
           command: |
-            env | grep ^DEPLOY_ | sed 's/DEPLOY_//g' > .env
+            env | sed -n 's/^DEPLOY_//p' > .env
             if [[ "${CIRCLE_BRANCH}" == "demo" ]]; then
-              env | grep ^DEMO_ | sed 's/DEMO_//g' >> .env
+              env | sed -n 's/^DEMO_//p' >> .env
               ./node_modules/ember-cli/bin/ember deploy demo --verbose --activate
             elif grep -q "v[0-9]\+\.[0-9]\+\.[0-9]\+" <<< "$CIRCLE_TAG"; then
-              env | grep ^PROD_ | sed 's/PROD_//g' >> .env
+              env | sed -n 's/^PROD_//p' >> .env
               ./node_modules/ember-cli/bin/ember deploy production --verbose --activate
             fi
 

--- a/circle.yml
+++ b/circle.yml
@@ -31,12 +31,12 @@ jobs:
             - bower_components
 
       - restore_cache:
-          key: node-deps-{{ checksum "package.json" }}
+          key: node-deps-{{ checksum "yarn.lock" }}
       - run:
           name: Node dependencies
           command: yarn
       - save_cache:
-          key: node-deps-{{ checksum "package.json" }}
+          key: node-deps-{{ checksum "yarn.lock" }}
           paths:
             - node_modules
 

--- a/circle.yml
+++ b/circle.yml
@@ -1,84 +1,127 @@
-machine:
-  node:
-    version: 8.6.0
-  environment:
-    JOBS: 2
+version: 2
 
-test:
-  override:
-    - yarn test:
+jobs:
+  build:
+    docker:
+      - image: circleci/node:8.6.0
         environment:
-          PATH: "/usr/bin:${PATH}"
+          JOBS: 2
 
-dependencies:
-  pre:
-    - curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add -
-    - echo "deb https://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
-    - sudo apt-get update && sudo apt-get install yarn
-  override:
-    - yarn global add bower grunt-cli:
-        environment:
-          PATH: "/usr/bin:${PATH}"
-    - yarn:
-        environment:
-          PATH: "/usr/bin:${PATH}"
-    - bower i
-    - grunt modernizr:dist
+    steps:
+      - checkout
+      - run: echo 'export PATH=/usr/bin:$PATH' >> $BASH_ENV
+      - run:
+          name: Install yarn
+          command: |
+            curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add -
+            echo "deb https://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
+            sudo apt-get update && sudo apt-get install yarn
 
-deployment:
-  prod:
-    tag: /v[0-9]+\.[0-9]+\.[0-9]+/
-    commands:
-      - ./node_modules/ember-cli/bin/ember deploy production --verbose --activate:
-          environment:
-            AWS_ACCESS_KEY_ID: $DEPLOY_AWS_ACCESS_KEY_ID
-            AWS_SECRET_ACCESS_KEY: $DEPLOY_AWS_SECRET_ACCESS_KEY
-            AWS_BUCKET: $PROD_AWS_BUCKET
-            AWS_REGION: $PROD_AWS_REGION
-            SSH_TUNNEL_USERNAME: $DEPLOY_SSH_TUNNEL_USERNAME
-            SSH_TUNNEL_HOST: $DEPLOY_SSH_TUNNEL_HOST
-            SSH_TUNNEL_DESTINATION_HOST: $PROD_REDIS_HOST
-            SSH_TUNNEL_DESTINATION_PORT: $PROD_REDIS_PORT
-            FINGERPRINT_PREPEND_URL: $PROD_FINGERPRINT_PREPEND_URL
-            SENTRY_DSN: $PROD_SENTRY_EMBER_DSN
-            SENTRY_PROJECT: $PROD_SENTRY_PROJECT
-            SENTRY_EMBER_SOURCEMAPS_KEY: $PROD_SENTRY_EMBER_SOURCEMAPS_KEY
-            WNYC_URL: $PROD_WNYC_URL
-            ADMIN_ROOT: $PROD_ADMIN_ROOT
-            ETAG_API: $PROD_ETAG_API
-            PUBLISHER_API: $PROD_PUBLISHER_API
-            AUTH_SERVICE: $PROD_AUTH_SERVICE
-            MEMBERSHIP_SERVICE: $PROD_MEMBERSHIP_SERVICE
-            PLATFORM_EVENTS_SERVICE: $PROD_PLATFORM_EVENTS_SERVICE
-            GOOGLE_TAG_MANAGER_ID: $PROD_GOOGLE_TAG_MANAGER_ID
-            GOOGLE_ANALYTICS: $PROD_GOOGLE_ANALYTICS
-            GOOGLE_API_V3_KEY: $PROD_GOOGLE_API_V3_KEY
-            FB_APP: $PROD_FB_APP
-  demo:
-    branch: demo
-    commands:
-      - ./node_modules/ember-cli/bin/ember deploy demo --verbose:
-          environment:
-            AWS_ACCESS_KEY_ID: $DEPLOY_AWS_ACCESS_KEY_ID
-            AWS_SECRET_ACCESS_KEY: $DEPLOY_AWS_SECRET_ACCESS_KEY
-            AWS_BUCKET: $DEMO_AWS_BUCKET
-            AWS_REGION: $DEMO_AWS_REGION
-            SSH_TUNNEL_USERNAME: $DEPLOY_SSH_TUNNEL_USERNAME
-            SSH_TUNNEL_HOST: $DEPLOY_SSH_TUNNEL_HOST
-            SSH_TUNNEL_DESTINATION_HOST: $DEMO_REDIS_HOST
-            SSH_TUNNEL_DESTINATION_PORT: $DEMO_REDIS_PORT
-            FINGERPRINT_PREPEND_URL: $DEMO_FINGERPRINT_PREPEND_URL
-            SENTRY_DSN: $DEMO_SENTRY_EMBER_DSN
-            SENTRY_PROJECT: $DEMO_SENTRY_PROJECT
-            SENTRY_EMBER_SOURCEMAPS_KEY: $DEMO_SENTRY_EMBER_SOURCEMAPS_KEY
-            WNYC_URL: $DEMO_WNYC_URL
-            ADMIN_ROOT: $DEMO_ADMIN_ROOT
-            ETAG_API: $DEMO_ETAG_API
-            PUBLISHER_API: $DEMO_PUBLISHER_API
-            AUTH_SERVICE: $DEMO_AUTH_SERVICE
-            MEMBERSHIP_SERVICE: $DEMO_MEMBERSHIP_SERVICE
-            PLATFORM_EVENTS_SERVICE: $DEMO_PLATFORM_EVENTS_SERVICE
-            GOOGLE_TAG_MANAGER_ID: $DEMO_GOOGLE_TAG_MANAGER_ID
-            GOOGLE_ANALYTICS: $DEMO_GOOGLE_ANALYTICS
-            GOOGLE_API_V3_KEY: $DEMO_GOOGLE_API_V3_KEY
-            FB_APP: $DEMO_FB_APP
+      - restore_cache:
+          key: grunt-and-bower
+      - run:
+          name: Install grunt and bower
+          command: yarn global add bower grunt-cli
+      - save_cache:
+          key: grunt-and-bower
+          paths:
+            - ~/.config/yarn/global
+      
+      - restore_cache:
+          key: bower-deps-{{ checksum "bower.json" }}
+      - run:
+          name: Install bower deps
+          command: bower i
+      - save_cache:
+          key: bower-deps-{{ checksum "bower.json" }}
+          paths:
+            - bower_components
+
+      - run:
+          name: Build modernizr
+          command: grunt modernizr:dist
+
+      - restore_cache:
+          key: node-deps-{{ checksum "package.json" }}
+      - run:
+          name: Node dependencies
+          commnd: yarn
+      - save_cache:
+          key: node-deps-{{ checksum "package.json" }}
+          paths:
+            - node_modules
+
+    test:
+      docker:
+        - image: circleci/node:8.6.0
+      steps:
+        - checkout
+        - run:
+            name: Test
+            command: yarn test
+
+    deploy:
+      command: |
+        export AWS_ACCESS_KEY_ID=$DEPLOY_AWS_ACCESS_KEY_ID
+        export AWS_SECRET_ACCESS_KEY=$DEPLOY_AWS_SECRET_ACCESS_KEY
+        export SSH_TUNNEL_USERNAME=$DEPLOY_SSH_TUNNEL_USERNAME
+        export SSH_TUNNEL_HOST=$DEPLOY_SSH_TUNNEL_HOST
+        if [[ "${CIRCLE_BRANCH}" == "demo" ]]; then
+          export AWS_BUCKET=$PROD_AWS_BUCKET
+          export AWS_REGION=$PROD_AWS_REGION
+          export SSH_TUNNEL_DESTINATION_HOST=$PROD_REDIS_HOST
+          export SSH_TUNNEL_DESTINATION_PORT=$PROD_REDIS_PORT
+          export FINGERPRINT_PREPEND_URL=$PROD_FINGERPRINT_PREPEND_URL
+          export SENTRY_DSN=$PROD_SENTRY_EMBER_DSN
+          export SENTRY_PROJECT=$PROD_SENTRY_PROJECT
+          export SENTRY_EMBER_SOURCEMAPS_KEY=$PROD_SENTRY_EMBER_SOURCEMAPS_KEY
+          export WNYC_URL=$PROD_WNYC_URL
+          export ADMIN_ROOT=$PROD_ADMIN_ROOT
+          export ETAG_API=$PROD_ETAG_API
+          export PUBLISHER_API=$PROD_PUBLISHER_API
+          export AUTH_SERVICE=$PROD_AUTH_SERVICE
+          export MEMBERSHIP_SERVICE=$PROD_MEMBERSHIP_SERVICE
+          export PLATFORM_EVENTS_SERVICE=$PROD_PLATFORM_EVENTS_SERVICE
+          export GOOGLE_TAG_MANAGER_ID=$PROD_GOOGLE_TAG_MANAGER_ID
+          export GOOGLE_ANALYTICS=$PROD_GOOGLE_ANALYTICS
+          export GOOGLE_API_V3_KEY=$PROD_GOOGLE_API_V3_KEY
+          export FB_APP=$PROD_FB_APP
+        elif grep -q "v[0-9]\+\.[0-9]\+\.[0-9]\+" <<< "$CIRCLE_TAG"; then
+          export AWS_BUCKET=$DEMO_AWS_BUCKET
+          export AWS_REGION=$DEMO_AWS_REGION
+          export SSH_TUNNEL_DESTINATION_HOST=$DEMO_REDIS_HOST
+          export SSH_TUNNEL_DESTINATION_PORT=$DEMO_REDIS_PORT
+          export FINGERPRINT_PREPEND_URL=$DEMO_FINGERPRINT_PREPEND_URL
+          export SENTRY_DSN=$DEMO_SENTRY_EMBER_DSN
+          export SENTRY_PROJECT=$DEMO_SENTRY_PROJECT
+          export SENTRY_EMBER_SOURCEMAPS_KEY=$DEMO_SENTRY_EMBER_SOURCEMAPS_KEY
+          export WNYC_URL=$DEMO_WNYC_URL
+          export ADMIN_ROOT=$DEMO_ADMIN_ROOT
+          export ETAG_API=$DEMO_ETAG_API
+          export PUBLISHER_API=$DEMO_PUBLISHER_API
+          export AUTH_SERVICE=$DEMO_AUTH_SERVICE
+          export MEMBERSHIP_SERVICE=$DEMO_MEMBERSHIP_SERVICE
+          export PLATFORM_EVENTS_SERVICE=$DEMO_PLATFORM_EVENTS_SERVICE
+          export GOOGLE_TAG_MANAGER_ID=$DEMO_GOOGLE_TAG_MANAGER_ID
+          export GOOGLE_ANALYTICS=$DEMO_GOOGLE_ANALYTICS
+          export GOOGLE_API_V3_KEY=$DEMO_GOOGLE_API_V3_KEY
+          export FB_APP=$DEMO_FB_APP
+        fi
+        ./node_modules/ember-cli/bin/ember deploy production --verbose --activate
+
+workflows:
+  version: 2
+  test-deploy:
+    jobs:
+      - test:
+        filters:
+          tags:
+            only: /.*/
+      - deploy:
+        requires:
+          - test
+        filters:
+          tags:
+            only: /^v[0-9]\.[0-9]\.[0-9]+/
+          branches:
+            only: demo

--- a/circle.yml
+++ b/circle.yml
@@ -59,7 +59,7 @@ jobs:
       - restore_cache:
           key: node-deps-{{ checksum "yarn.lock" }}
       - restore_cache:
-          key: modernizr-$CIRCLE_SHA1
+          key: modernizr-{{ .Revision }}
       - run:
           name: Test
           command: ./node_modules/ember-cli/bin/ember test
@@ -76,7 +76,7 @@ jobs:
       - restore_cache:
           key: node-deps-{{ checksum "yarn.lock" }}
       - restore_cache:
-          key: modernizr-$CIRCLE_SHA1
+          key: modernizr-{{ .Revision }}
       - run:
           name: Deploy to S3 and Redis
           command: |

--- a/circle.yml
+++ b/circle.yml
@@ -9,11 +9,6 @@ jobs:
 
     steps:
       - checkout
-      - run:
-          name: add yarn global path to path
-          command: |
-            export PATH="$PATH:~/.config/yarn/global/node_modules/.bin/" >> $BASH_ENV
-            source $BASH_ENV
       - restore_cache:
           key: grunt-and-bower
       - run:
@@ -29,6 +24,8 @@ jobs:
       - run:
           name: Install bower deps
           command: bower i
+          environment:
+            PATH: $PATH:~/.config/yarn/global/node_modules/.bin/ 
       - save_cache:
           key: bower-deps-{{ checksum "bower.json" }}
           paths:

--- a/circle.yml
+++ b/circle.yml
@@ -49,8 +49,10 @@ jobs:
   test:
     docker:
       - image: circleci/node:8.6.0
+      - image: selenium/standalone-chrome:3.1.0
         environment:
           JOBS: 2
+
     steps:
       - checkout
       - restore_cache:

--- a/circle.yml
+++ b/circle.yml
@@ -9,14 +9,6 @@ jobs:
 
     steps:
       - checkout
-      - run: echo 'export PATH=/usr/bin:$PATH' >> $BASH_ENV
-      - run:
-          name: Install yarn
-          command: |
-            curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add -
-            echo "deb https://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
-            sudo apt-get update && sudo apt-get install yarn
-
       - restore_cache:
           key: grunt-and-bower
       - run:

--- a/circle.yml
+++ b/circle.yml
@@ -9,7 +9,7 @@ jobs:
 
     steps:
       - checkout
-      - run
+      - run:
           name: add yarn global path to path
           command: |
             export PATH="$PATH:~/.config/yarn/global/node_modules/.bin/" >> ~/.bashrc

--- a/circle.yml
+++ b/circle.yml
@@ -4,8 +4,6 @@ jobs:
   build:
     docker:
       - image: circleci/node:8.6.0
-        environment:
-          JOBS: 2
 
     steps:
       - checkout
@@ -44,13 +42,15 @@ jobs:
           name: Build modernizr
           command: ~/.config/yarn/global/node_modules/.bin/grunt modernizr:dist
       - save_cache:
-          key: modernizr-$CIRCLE_SHA1
+          key: modernizr-{{ .Revision }}
           paths:
             - vendor/modernizr/modernizr-build.js
 
   test:
     docker:
       - image: circleci/node:8.6.0
+        environment:
+          JOBS: 2
     steps:
       - checkout
       - restore_cache:
@@ -66,6 +66,8 @@ jobs:
   deploy:
     docker:
       - image: circleci/node:8.6.0
+        environment:
+          JOBS: 2
     steps:
       - checkout
       - restore_cache:

--- a/circle.yml
+++ b/circle.yml
@@ -85,26 +85,6 @@ jobs:
             export SSH_TUNNEL_USERNAME=$DEPLOY_SSH_TUNNEL_USERNAME
             export SSH_TUNNEL_HOST=$DEPLOY_SSH_TUNNEL_HOST
             if [[ "${CIRCLE_BRANCH}" == "demo" ]]; then
-              export AWS_BUCKET=$PROD_AWS_BUCKET
-              export AWS_REGION=$PROD_AWS_REGION
-              export SSH_TUNNEL_DESTINATION_HOST=$PROD_REDIS_HOST
-              export SSH_TUNNEL_DESTINATION_PORT=$PROD_REDIS_PORT
-              export FINGERPRINT_PREPEND_URL=$PROD_FINGERPRINT_PREPEND_URL
-              export SENTRY_DSN=$PROD_SENTRY_EMBER_DSN
-              export SENTRY_PROJECT=$PROD_SENTRY_PROJECT
-              export SENTRY_EMBER_SOURCEMAPS_KEY=$PROD_SENTRY_EMBER_SOURCEMAPS_KEY
-              export WNYC_URL=$PROD_WNYC_URL
-              export ADMIN_ROOT=$PROD_ADMIN_ROOT
-              export ETAG_API=$PROD_ETAG_API
-              export PUBLISHER_API=$PROD_PUBLISHER_API
-              export AUTH_SERVICE=$PROD_AUTH_SERVICE
-              export MEMBERSHIP_SERVICE=$PROD_MEMBERSHIP_SERVICE
-              export PLATFORM_EVENTS_SERVICE=$PROD_PLATFORM_EVENTS_SERVICE
-              export GOOGLE_TAG_MANAGER_ID=$PROD_GOOGLE_TAG_MANAGER_ID
-              export GOOGLE_ANALYTICS=$PROD_GOOGLE_ANALYTICS
-              export GOOGLE_API_V3_KEY=$PROD_GOOGLE_API_V3_KEY
-              export FB_APP=$PROD_FB_APP
-            elif grep -q "v[0-9]\+\.[0-9]\+\.[0-9]\+" <<< "$CIRCLE_TAG"; then
               export AWS_BUCKET=$DEMO_AWS_BUCKET
               export AWS_REGION=$DEMO_AWS_REGION
               export SSH_TUNNEL_DESTINATION_HOST=$DEMO_REDIS_HOST
@@ -124,8 +104,29 @@ jobs:
               export GOOGLE_ANALYTICS=$DEMO_GOOGLE_ANALYTICS
               export GOOGLE_API_V3_KEY=$DEMO_GOOGLE_API_V3_KEY
               export FB_APP=$DEMO_FB_APP
+              ./node_modules/ember-cli/bin/ember deploy demo --verbose --activate
+            elif grep -q "v[0-9]\+\.[0-9]\+\.[0-9]\+" <<< "$CIRCLE_TAG"; then
+              export AWS_BUCKET=$PROD_AWS_BUCKET
+              export AWS_REGION=$PROD_AWS_REGION
+              export SSH_TUNNEL_DESTINATION_HOST=$PROD_REDIS_HOST
+              export SSH_TUNNEL_DESTINATION_PORT=$PROD_REDIS_PORT
+              export FINGERPRINT_PREPEND_URL=$PROD_FINGERPRINT_PREPEND_URL
+              export SENTRY_DSN=$PROD_SENTRY_EMBER_DSN
+              export SENTRY_PROJECT=$PROD_SENTRY_PROJECT
+              export SENTRY_EMBER_SOURCEMAPS_KEY=$PROD_SENTRY_EMBER_SOURCEMAPS_KEY
+              export WNYC_URL=$PROD_WNYC_URL
+              export ADMIN_ROOT=$PROD_ADMIN_ROOT
+              export ETAG_API=$PROD_ETAG_API
+              export PUBLISHER_API=$PROD_PUBLISHER_API
+              export AUTH_SERVICE=$PROD_AUTH_SERVICE
+              export MEMBERSHIP_SERVICE=$PROD_MEMBERSHIP_SERVICE
+              export PLATFORM_EVENTS_SERVICE=$PROD_PLATFORM_EVENTS_SERVICE
+              export GOOGLE_TAG_MANAGER_ID=$PROD_GOOGLE_TAG_MANAGER_ID
+              export GOOGLE_ANALYTICS=$PROD_GOOGLE_ANALYTICS
+              export GOOGLE_API_V3_KEY=$PROD_GOOGLE_API_V3_KEY
+              export FB_APP=$PROD_FB_APP
+              ./node_modules/ember-cli/bin/ember deploy production --verbose --activate
             fi
-            ./node_modules/ember-cli/bin/ember deploy production --verbose --activate
 
 workflows:
   version: 2

--- a/circle.yml
+++ b/circle.yml
@@ -54,53 +54,59 @@ jobs:
           command: yarn test
 
   deploy:
-    command: |
-      export AWS_ACCESS_KEY_ID=$DEPLOY_AWS_ACCESS_KEY_ID
-      export AWS_SECRET_ACCESS_KEY=$DEPLOY_AWS_SECRET_ACCESS_KEY
-      export SSH_TUNNEL_USERNAME=$DEPLOY_SSH_TUNNEL_USERNAME
-      export SSH_TUNNEL_HOST=$DEPLOY_SSH_TUNNEL_HOST
-      if [[ "${CIRCLE_BRANCH}" == "demo" ]]; then
-        export AWS_BUCKET=$PROD_AWS_BUCKET
-        export AWS_REGION=$PROD_AWS_REGION
-        export SSH_TUNNEL_DESTINATION_HOST=$PROD_REDIS_HOST
-        export SSH_TUNNEL_DESTINATION_PORT=$PROD_REDIS_PORT
-        export FINGERPRINT_PREPEND_URL=$PROD_FINGERPRINT_PREPEND_URL
-        export SENTRY_DSN=$PROD_SENTRY_EMBER_DSN
-        export SENTRY_PROJECT=$PROD_SENTRY_PROJECT
-        export SENTRY_EMBER_SOURCEMAPS_KEY=$PROD_SENTRY_EMBER_SOURCEMAPS_KEY
-        export WNYC_URL=$PROD_WNYC_URL
-        export ADMIN_ROOT=$PROD_ADMIN_ROOT
-        export ETAG_API=$PROD_ETAG_API
-        export PUBLISHER_API=$PROD_PUBLISHER_API
-        export AUTH_SERVICE=$PROD_AUTH_SERVICE
-        export MEMBERSHIP_SERVICE=$PROD_MEMBERSHIP_SERVICE
-        export PLATFORM_EVENTS_SERVICE=$PROD_PLATFORM_EVENTS_SERVICE
-        export GOOGLE_TAG_MANAGER_ID=$PROD_GOOGLE_TAG_MANAGER_ID
-        export GOOGLE_ANALYTICS=$PROD_GOOGLE_ANALYTICS
-        export GOOGLE_API_V3_KEY=$PROD_GOOGLE_API_V3_KEY
-        export FB_APP=$PROD_FB_APP
-      elif grep -q "v[0-9]\+\.[0-9]\+\.[0-9]\+" <<< "$CIRCLE_TAG"; then
-        export AWS_BUCKET=$DEMO_AWS_BUCKET
-        export AWS_REGION=$DEMO_AWS_REGION
-        export SSH_TUNNEL_DESTINATION_HOST=$DEMO_REDIS_HOST
-        export SSH_TUNNEL_DESTINATION_PORT=$DEMO_REDIS_PORT
-        export FINGERPRINT_PREPEND_URL=$DEMO_FINGERPRINT_PREPEND_URL
-        export SENTRY_DSN=$DEMO_SENTRY_EMBER_DSN
-        export SENTRY_PROJECT=$DEMO_SENTRY_PROJECT
-        export SENTRY_EMBER_SOURCEMAPS_KEY=$DEMO_SENTRY_EMBER_SOURCEMAPS_KEY
-        export WNYC_URL=$DEMO_WNYC_URL
-        export ADMIN_ROOT=$DEMO_ADMIN_ROOT
-        export ETAG_API=$DEMO_ETAG_API
-        export PUBLISHER_API=$DEMO_PUBLISHER_API
-        export AUTH_SERVICE=$DEMO_AUTH_SERVICE
-        export MEMBERSHIP_SERVICE=$DEMO_MEMBERSHIP_SERVICE
-        export PLATFORM_EVENTS_SERVICE=$DEMO_PLATFORM_EVENTS_SERVICE
-        export GOOGLE_TAG_MANAGER_ID=$DEMO_GOOGLE_TAG_MANAGER_ID
-        export GOOGLE_ANALYTICS=$DEMO_GOOGLE_ANALYTICS
-        export GOOGLE_API_V3_KEY=$DEMO_GOOGLE_API_V3_KEY
-        export FB_APP=$DEMO_FB_APP
-      fi
-      ./node_modules/ember-cli/bin/ember deploy production --verbose --activate
+    docker:
+      - image: circleci/node:8.6.0
+    steps:
+      - checkout
+      - run:
+          name: Deploy to S3 and Redis
+          command: |
+            export AWS_ACCESS_KEY_ID=$DEPLOY_AWS_ACCESS_KEY_ID
+            export AWS_SECRET_ACCESS_KEY=$DEPLOY_AWS_SECRET_ACCESS_KEY
+            export SSH_TUNNEL_USERNAME=$DEPLOY_SSH_TUNNEL_USERNAME
+            export SSH_TUNNEL_HOST=$DEPLOY_SSH_TUNNEL_HOST
+            if [[ "${CIRCLE_BRANCH}" == "demo" ]]; then
+              export AWS_BUCKET=$PROD_AWS_BUCKET
+              export AWS_REGION=$PROD_AWS_REGION
+              export SSH_TUNNEL_DESTINATION_HOST=$PROD_REDIS_HOST
+              export SSH_TUNNEL_DESTINATION_PORT=$PROD_REDIS_PORT
+              export FINGERPRINT_PREPEND_URL=$PROD_FINGERPRINT_PREPEND_URL
+              export SENTRY_DSN=$PROD_SENTRY_EMBER_DSN
+              export SENTRY_PROJECT=$PROD_SENTRY_PROJECT
+              export SENTRY_EMBER_SOURCEMAPS_KEY=$PROD_SENTRY_EMBER_SOURCEMAPS_KEY
+              export WNYC_URL=$PROD_WNYC_URL
+              export ADMIN_ROOT=$PROD_ADMIN_ROOT
+              export ETAG_API=$PROD_ETAG_API
+              export PUBLISHER_API=$PROD_PUBLISHER_API
+              export AUTH_SERVICE=$PROD_AUTH_SERVICE
+              export MEMBERSHIP_SERVICE=$PROD_MEMBERSHIP_SERVICE
+              export PLATFORM_EVENTS_SERVICE=$PROD_PLATFORM_EVENTS_SERVICE
+              export GOOGLE_TAG_MANAGER_ID=$PROD_GOOGLE_TAG_MANAGER_ID
+              export GOOGLE_ANALYTICS=$PROD_GOOGLE_ANALYTICS
+              export GOOGLE_API_V3_KEY=$PROD_GOOGLE_API_V3_KEY
+              export FB_APP=$PROD_FB_APP
+            elif grep -q "v[0-9]\+\.[0-9]\+\.[0-9]\+" <<< "$CIRCLE_TAG"; then
+              export AWS_BUCKET=$DEMO_AWS_BUCKET
+              export AWS_REGION=$DEMO_AWS_REGION
+              export SSH_TUNNEL_DESTINATION_HOST=$DEMO_REDIS_HOST
+              export SSH_TUNNEL_DESTINATION_PORT=$DEMO_REDIS_PORT
+              export FINGERPRINT_PREPEND_URL=$DEMO_FINGERPRINT_PREPEND_URL
+              export SENTRY_DSN=$DEMO_SENTRY_EMBER_DSN
+              export SENTRY_PROJECT=$DEMO_SENTRY_PROJECT
+              export SENTRY_EMBER_SOURCEMAPS_KEY=$DEMO_SENTRY_EMBER_SOURCEMAPS_KEY
+              export WNYC_URL=$DEMO_WNYC_URL
+              export ADMIN_ROOT=$DEMO_ADMIN_ROOT
+              export ETAG_API=$DEMO_ETAG_API
+              export PUBLISHER_API=$DEMO_PUBLISHER_API
+              export AUTH_SERVICE=$DEMO_AUTH_SERVICE
+              export MEMBERSHIP_SERVICE=$DEMO_MEMBERSHIP_SERVICE
+              export PLATFORM_EVENTS_SERVICE=$DEMO_PLATFORM_EVENTS_SERVICE
+              export GOOGLE_TAG_MANAGER_ID=$DEMO_GOOGLE_TAG_MANAGER_ID
+              export GOOGLE_ANALYTICS=$DEMO_GOOGLE_ANALYTICS
+              export GOOGLE_API_V3_KEY=$DEMO_GOOGLE_API_V3_KEY
+              export FB_APP=$DEMO_FB_APP
+            fi
+            ./node_modules/ember-cli/bin/ember deploy production --verbose --activate
 
 workflows:
   version: 2

--- a/circle.yml
+++ b/circle.yml
@@ -48,8 +48,7 @@ jobs:
 
   test:
     docker:
-      - image: circleci/node:8.6.0
-      - image: selenium/standalone-chrome:3.1.0
+      - image: circleci/node:8.6.0-browsers
         environment:
           JOBS: 2
 

--- a/circle.yml
+++ b/circle.yml
@@ -23,9 +23,7 @@ jobs:
           key: bower-deps-{{ checksum "bower.json" }}
       - run:
           name: Install bower deps
-          command: bower i
-          environment:
-            PATH: $PATH:~/.config/yarn/global/node_modules/.bin/ 
+          command: ~/.config/yarn/global/node_modules/.bin/bower i
       - save_cache:
           key: bower-deps-{{ checksum "bower.json" }}
           paths:
@@ -33,7 +31,7 @@ jobs:
 
       - run:
           name: Build modernizr
-          command: grunt modernizr:dist
+          command: ~/.config/yarn/global/node_modules/.bin/grunt modernizr:dist
 
       - restore_cache:
           key: node-deps-{{ checksum "package.json" }}

--- a/circle.yml
+++ b/circle.yml
@@ -9,7 +9,7 @@ jobs:
 
     steps:
       - checkout
-      - run: export PATH="$PATH:~/.config/yarn/global/node_modules/.bin/" >> $BASH_ENV
+      - run: export PATH="$PATH:~/.config/yarn/global/node_modules/.bin/"
       - restore_cache:
           key: grunt-and-bower
       - run:

--- a/circle.yml
+++ b/circle.yml
@@ -44,63 +44,63 @@ jobs:
           name: Build modernizr
           command: ~/.config/yarn/global/node_modules/.bin/grunt modernizr:dist
 
-    test:
-      docker:
-        - image: circleci/node:8.6.0
-      steps:
-        - checkout
-        - run:
-            name: Test
-            command: yarn test
+  test:
+    docker:
+      - image: circleci/node:8.6.0
+    steps:
+      - checkout
+      - run:
+          name: Test
+          command: yarn test
 
-    deploy:
-      command: |
-        export AWS_ACCESS_KEY_ID=$DEPLOY_AWS_ACCESS_KEY_ID
-        export AWS_SECRET_ACCESS_KEY=$DEPLOY_AWS_SECRET_ACCESS_KEY
-        export SSH_TUNNEL_USERNAME=$DEPLOY_SSH_TUNNEL_USERNAME
-        export SSH_TUNNEL_HOST=$DEPLOY_SSH_TUNNEL_HOST
-        if [[ "${CIRCLE_BRANCH}" == "demo" ]]; then
-          export AWS_BUCKET=$PROD_AWS_BUCKET
-          export AWS_REGION=$PROD_AWS_REGION
-          export SSH_TUNNEL_DESTINATION_HOST=$PROD_REDIS_HOST
-          export SSH_TUNNEL_DESTINATION_PORT=$PROD_REDIS_PORT
-          export FINGERPRINT_PREPEND_URL=$PROD_FINGERPRINT_PREPEND_URL
-          export SENTRY_DSN=$PROD_SENTRY_EMBER_DSN
-          export SENTRY_PROJECT=$PROD_SENTRY_PROJECT
-          export SENTRY_EMBER_SOURCEMAPS_KEY=$PROD_SENTRY_EMBER_SOURCEMAPS_KEY
-          export WNYC_URL=$PROD_WNYC_URL
-          export ADMIN_ROOT=$PROD_ADMIN_ROOT
-          export ETAG_API=$PROD_ETAG_API
-          export PUBLISHER_API=$PROD_PUBLISHER_API
-          export AUTH_SERVICE=$PROD_AUTH_SERVICE
-          export MEMBERSHIP_SERVICE=$PROD_MEMBERSHIP_SERVICE
-          export PLATFORM_EVENTS_SERVICE=$PROD_PLATFORM_EVENTS_SERVICE
-          export GOOGLE_TAG_MANAGER_ID=$PROD_GOOGLE_TAG_MANAGER_ID
-          export GOOGLE_ANALYTICS=$PROD_GOOGLE_ANALYTICS
-          export GOOGLE_API_V3_KEY=$PROD_GOOGLE_API_V3_KEY
-          export FB_APP=$PROD_FB_APP
-        elif grep -q "v[0-9]\+\.[0-9]\+\.[0-9]\+" <<< "$CIRCLE_TAG"; then
-          export AWS_BUCKET=$DEMO_AWS_BUCKET
-          export AWS_REGION=$DEMO_AWS_REGION
-          export SSH_TUNNEL_DESTINATION_HOST=$DEMO_REDIS_HOST
-          export SSH_TUNNEL_DESTINATION_PORT=$DEMO_REDIS_PORT
-          export FINGERPRINT_PREPEND_URL=$DEMO_FINGERPRINT_PREPEND_URL
-          export SENTRY_DSN=$DEMO_SENTRY_EMBER_DSN
-          export SENTRY_PROJECT=$DEMO_SENTRY_PROJECT
-          export SENTRY_EMBER_SOURCEMAPS_KEY=$DEMO_SENTRY_EMBER_SOURCEMAPS_KEY
-          export WNYC_URL=$DEMO_WNYC_URL
-          export ADMIN_ROOT=$DEMO_ADMIN_ROOT
-          export ETAG_API=$DEMO_ETAG_API
-          export PUBLISHER_API=$DEMO_PUBLISHER_API
-          export AUTH_SERVICE=$DEMO_AUTH_SERVICE
-          export MEMBERSHIP_SERVICE=$DEMO_MEMBERSHIP_SERVICE
-          export PLATFORM_EVENTS_SERVICE=$DEMO_PLATFORM_EVENTS_SERVICE
-          export GOOGLE_TAG_MANAGER_ID=$DEMO_GOOGLE_TAG_MANAGER_ID
-          export GOOGLE_ANALYTICS=$DEMO_GOOGLE_ANALYTICS
-          export GOOGLE_API_V3_KEY=$DEMO_GOOGLE_API_V3_KEY
-          export FB_APP=$DEMO_FB_APP
-        fi
-        ./node_modules/ember-cli/bin/ember deploy production --verbose --activate
+  deploy:
+    command: |
+      export AWS_ACCESS_KEY_ID=$DEPLOY_AWS_ACCESS_KEY_ID
+      export AWS_SECRET_ACCESS_KEY=$DEPLOY_AWS_SECRET_ACCESS_KEY
+      export SSH_TUNNEL_USERNAME=$DEPLOY_SSH_TUNNEL_USERNAME
+      export SSH_TUNNEL_HOST=$DEPLOY_SSH_TUNNEL_HOST
+      if [[ "${CIRCLE_BRANCH}" == "demo" ]]; then
+        export AWS_BUCKET=$PROD_AWS_BUCKET
+        export AWS_REGION=$PROD_AWS_REGION
+        export SSH_TUNNEL_DESTINATION_HOST=$PROD_REDIS_HOST
+        export SSH_TUNNEL_DESTINATION_PORT=$PROD_REDIS_PORT
+        export FINGERPRINT_PREPEND_URL=$PROD_FINGERPRINT_PREPEND_URL
+        export SENTRY_DSN=$PROD_SENTRY_EMBER_DSN
+        export SENTRY_PROJECT=$PROD_SENTRY_PROJECT
+        export SENTRY_EMBER_SOURCEMAPS_KEY=$PROD_SENTRY_EMBER_SOURCEMAPS_KEY
+        export WNYC_URL=$PROD_WNYC_URL
+        export ADMIN_ROOT=$PROD_ADMIN_ROOT
+        export ETAG_API=$PROD_ETAG_API
+        export PUBLISHER_API=$PROD_PUBLISHER_API
+        export AUTH_SERVICE=$PROD_AUTH_SERVICE
+        export MEMBERSHIP_SERVICE=$PROD_MEMBERSHIP_SERVICE
+        export PLATFORM_EVENTS_SERVICE=$PROD_PLATFORM_EVENTS_SERVICE
+        export GOOGLE_TAG_MANAGER_ID=$PROD_GOOGLE_TAG_MANAGER_ID
+        export GOOGLE_ANALYTICS=$PROD_GOOGLE_ANALYTICS
+        export GOOGLE_API_V3_KEY=$PROD_GOOGLE_API_V3_KEY
+        export FB_APP=$PROD_FB_APP
+      elif grep -q "v[0-9]\+\.[0-9]\+\.[0-9]\+" <<< "$CIRCLE_TAG"; then
+        export AWS_BUCKET=$DEMO_AWS_BUCKET
+        export AWS_REGION=$DEMO_AWS_REGION
+        export SSH_TUNNEL_DESTINATION_HOST=$DEMO_REDIS_HOST
+        export SSH_TUNNEL_DESTINATION_PORT=$DEMO_REDIS_PORT
+        export FINGERPRINT_PREPEND_URL=$DEMO_FINGERPRINT_PREPEND_URL
+        export SENTRY_DSN=$DEMO_SENTRY_EMBER_DSN
+        export SENTRY_PROJECT=$DEMO_SENTRY_PROJECT
+        export SENTRY_EMBER_SOURCEMAPS_KEY=$DEMO_SENTRY_EMBER_SOURCEMAPS_KEY
+        export WNYC_URL=$DEMO_WNYC_URL
+        export ADMIN_ROOT=$DEMO_ADMIN_ROOT
+        export ETAG_API=$DEMO_ETAG_API
+        export PUBLISHER_API=$DEMO_PUBLISHER_API
+        export AUTH_SERVICE=$DEMO_AUTH_SERVICE
+        export MEMBERSHIP_SERVICE=$DEMO_MEMBERSHIP_SERVICE
+        export PLATFORM_EVENTS_SERVICE=$DEMO_PLATFORM_EVENTS_SERVICE
+        export GOOGLE_TAG_MANAGER_ID=$DEMO_GOOGLE_TAG_MANAGER_ID
+        export GOOGLE_ANALYTICS=$DEMO_GOOGLE_ANALYTICS
+        export GOOGLE_API_V3_KEY=$DEMO_GOOGLE_API_V3_KEY
+        export FB_APP=$DEMO_FB_APP
+      fi
+      ./node_modules/ember-cli/bin/ember deploy production --verbose --activate
 
 workflows:
   version: 2

--- a/circle.yml
+++ b/circle.yml
@@ -51,7 +51,7 @@ jobs:
       - checkout
       - run:
           name: Test
-          command: yarn test
+          command: ./node_modules/ember-cli/bin/ember test
 
   deploy:
     docker:

--- a/circle.yml
+++ b/circle.yml
@@ -9,6 +9,7 @@ jobs:
 
     steps:
       - checkout
+      - run: export PATH="$PATH:~/.config/yarn/global/node_modules/.bin/" >> $BASH_ENV
       - restore_cache:
           key: grunt-and-bower
       - run:

--- a/circle.yml
+++ b/circle.yml
@@ -111,17 +111,23 @@ jobs:
 
 workflows:
   version: 2
-  test-deploy:
+  buld-test-deploy:
     jobs:
+      - build:
+          filters:
+            tags:
+              only: /.*/
       - test:
-        filters:
-          tags:
-            only: /.*/
+          filters:
+            tags:
+              only: /.*/
+          requires:
+            - build
       - deploy:
-        requires:
-          - test
-        filters:
-          tags:
-            only: /^v[0-9]\.[0-9]\.[0-9]+/
-          branches:
-            only: demo
+          requires:
+            - test
+          filters:
+            tags:
+              only: /^v[0-9]\.[0-9]\.[0-9]+/
+            branches:
+              only: demo

--- a/circle.yml
+++ b/circle.yml
@@ -9,6 +9,7 @@ jobs:
 
     steps:
       - checkout
+
       - restore_cache:
           key: grunt-and-bower
       - run:
@@ -29,10 +30,6 @@ jobs:
           paths:
             - bower_components
 
-      - run:
-          name: Build modernizr
-          command: ~/.config/yarn/global/node_modules/.bin/grunt modernizr:dist
-
       - restore_cache:
           key: node-deps-{{ checksum "package.json" }}
       - run:
@@ -42,6 +39,10 @@ jobs:
           key: node-deps-{{ checksum "package.json" }}
           paths:
             - node_modules
+
+      - run:
+          name: Build modernizr
+          command: ~/.config/yarn/global/node_modules/.bin/grunt modernizr:dist
 
     test:
       docker:

--- a/circle.yml
+++ b/circle.yml
@@ -43,12 +43,20 @@ jobs:
       - run:
           name: Build modernizr
           command: ~/.config/yarn/global/node_modules/.bin/grunt modernizr:dist
+      - save_cache:
+          key: modernizr-$CIRCLE_SHA1
 
   test:
     docker:
       - image: circleci/node:8.6.0
     steps:
       - checkout
+      - restore_cache:
+          key: bower-deps-{{ checksum "bower.json" }}
+      - restore_cache:
+          key: node-deps-{{ checksum "yarn.lock" }}
+      - restore_cache:
+          key: modernizr-$CIRCLE_SHA1
       - run:
           name: Test
           command: ./node_modules/ember-cli/bin/ember test
@@ -58,6 +66,12 @@ jobs:
       - image: circleci/node:8.6.0
     steps:
       - checkout
+      - restore_cache:
+          key: bower-deps-{{ checksum "bower.json" }}
+      - restore_cache:
+          key: node-deps-{{ checksum "yarn.lock" }}
+      - restore_cache:
+          key: modernizr-$CIRCLE_SHA1
       - run:
           name: Deploy to S3 and Redis
           command: |

--- a/circle.yml
+++ b/circle.yml
@@ -45,6 +45,8 @@ jobs:
           command: ~/.config/yarn/global/node_modules/.bin/grunt modernizr:dist
       - save_cache:
           key: modernizr-$CIRCLE_SHA1
+          paths:
+            - vendor/modernizr/modernizr-build.js
 
   test:
     docker:

--- a/circle.yml
+++ b/circle.yml
@@ -45,7 +45,7 @@ jobs:
           key: node-deps-{{ checksum "package.json" }}
       - run:
           name: Node dependencies
-          commnd: yarn
+          command: yarn
       - save_cache:
           key: node-deps-{{ checksum "package.json" }}
           paths:

--- a/circle.yml
+++ b/circle.yml
@@ -12,8 +12,8 @@ jobs:
       - run:
           name: add yarn global path to path
           command: |
-            export PATH="$PATH:~/.config/yarn/global/node_modules/.bin/" >> ~/.bashrc
-            source .bashrc
+            export PATH="$PATH:~/.config/yarn/global/node_modules/.bin/" >> $BASH_ENV
+            source $BASH_ENV
       - restore_cache:
           key: grunt-and-bower
       - run:

--- a/circle.yml
+++ b/circle.yml
@@ -80,51 +80,12 @@ jobs:
       - run:
           name: Deploy to S3 and Redis
           command: |
-            export AWS_ACCESS_KEY_ID=$DEPLOY_AWS_ACCESS_KEY_ID
-            export AWS_SECRET_ACCESS_KEY=$DEPLOY_AWS_SECRET_ACCESS_KEY
-            export SSH_TUNNEL_USERNAME=$DEPLOY_SSH_TUNNEL_USERNAME
-            export SSH_TUNNEL_HOST=$DEPLOY_SSH_TUNNEL_HOST
+            env | grep ^DEPLOY_ | sed 's/DEPLOY_//g' > .env
             if [[ "${CIRCLE_BRANCH}" == "demo" ]]; then
-              export AWS_BUCKET=$DEMO_AWS_BUCKET
-              export AWS_REGION=$DEMO_AWS_REGION
-              export SSH_TUNNEL_DESTINATION_HOST=$DEMO_REDIS_HOST
-              export SSH_TUNNEL_DESTINATION_PORT=$DEMO_REDIS_PORT
-              export FINGERPRINT_PREPEND_URL=$DEMO_FINGERPRINT_PREPEND_URL
-              export SENTRY_DSN=$DEMO_SENTRY_EMBER_DSN
-              export SENTRY_PROJECT=$DEMO_SENTRY_PROJECT
-              export SENTRY_EMBER_SOURCEMAPS_KEY=$DEMO_SENTRY_EMBER_SOURCEMAPS_KEY
-              export WNYC_URL=$DEMO_WNYC_URL
-              export ADMIN_ROOT=$DEMO_ADMIN_ROOT
-              export ETAG_API=$DEMO_ETAG_API
-              export PUBLISHER_API=$DEMO_PUBLISHER_API
-              export AUTH_SERVICE=$DEMO_AUTH_SERVICE
-              export MEMBERSHIP_SERVICE=$DEMO_MEMBERSHIP_SERVICE
-              export PLATFORM_EVENTS_SERVICE=$DEMO_PLATFORM_EVENTS_SERVICE
-              export GOOGLE_TAG_MANAGER_ID=$DEMO_GOOGLE_TAG_MANAGER_ID
-              export GOOGLE_ANALYTICS=$DEMO_GOOGLE_ANALYTICS
-              export GOOGLE_API_V3_KEY=$DEMO_GOOGLE_API_V3_KEY
-              export FB_APP=$DEMO_FB_APP
+              env | grep ^DEMO_ | sed 's/DEMO_//g' >> .env
               ./node_modules/ember-cli/bin/ember deploy demo --verbose --activate
             elif grep -q "v[0-9]\+\.[0-9]\+\.[0-9]\+" <<< "$CIRCLE_TAG"; then
-              export AWS_BUCKET=$PROD_AWS_BUCKET
-              export AWS_REGION=$PROD_AWS_REGION
-              export SSH_TUNNEL_DESTINATION_HOST=$PROD_REDIS_HOST
-              export SSH_TUNNEL_DESTINATION_PORT=$PROD_REDIS_PORT
-              export FINGERPRINT_PREPEND_URL=$PROD_FINGERPRINT_PREPEND_URL
-              export SENTRY_DSN=$PROD_SENTRY_EMBER_DSN
-              export SENTRY_PROJECT=$PROD_SENTRY_PROJECT
-              export SENTRY_EMBER_SOURCEMAPS_KEY=$PROD_SENTRY_EMBER_SOURCEMAPS_KEY
-              export WNYC_URL=$PROD_WNYC_URL
-              export ADMIN_ROOT=$PROD_ADMIN_ROOT
-              export ETAG_API=$PROD_ETAG_API
-              export PUBLISHER_API=$PROD_PUBLISHER_API
-              export AUTH_SERVICE=$PROD_AUTH_SERVICE
-              export MEMBERSHIP_SERVICE=$PROD_MEMBERSHIP_SERVICE
-              export PLATFORM_EVENTS_SERVICE=$PROD_PLATFORM_EVENTS_SERVICE
-              export GOOGLE_TAG_MANAGER_ID=$PROD_GOOGLE_TAG_MANAGER_ID
-              export GOOGLE_ANALYTICS=$PROD_GOOGLE_ANALYTICS
-              export GOOGLE_API_V3_KEY=$PROD_GOOGLE_API_V3_KEY
-              export FB_APP=$PROD_FB_APP
+              env | grep ^PROD_ | sed 's/PROD_//g' >> .env
               ./node_modules/ember-cli/bin/ember deploy production --verbose --activate
             fi
 

--- a/circle.yml
+++ b/circle.yml
@@ -9,7 +9,11 @@ jobs:
 
     steps:
       - checkout
-      - run: export PATH="$PATH:~/.config/yarn/global/node_modules/.bin/"
+      - run
+          name: add yarn global path to path
+          command: |
+            export PATH="$PATH:~/.config/yarn/global/node_modules/.bin/" >> ~/.bashrc
+            source .bashrc
       - restore_cache:
           key: grunt-and-bower
       - run:


### PR DESCRIPTION
This updates the build to circle ci 2.0

There are 3 jobs, which run in sequence: `build`, `test`, `deploy`.

The `build` job installs all the global and local node dependencies. We don't need to manually install yarn anymore on circle 2.0.