### PR TITLE
Fix http img ref

### DIFF
--- a/app/components/site-chrome/site-footer/template.hbs
+++ b/app/components/site-chrome/site-footer/template.hbs
@@ -365,7 +365,7 @@
           </div>
           <div class="l-col1of3 middle-narrow-up">
             <div class="text--small {{if media.isMediumAndUp 'alignright' 'aligncenter'}}">
-              <span class="text--lightgray">WNYC is supported by <img class="icon--jlgreene--footer" src="http://www.wnyc.org/i/raw/1/wnyc-footer.png"></span>
+              <span class="text--lightgray">WNYC is supported by <img class="icon--jlgreene--footer" src="//www.wnyc.org/i/raw/1/wnyc-footer.png"></span>
             </div>
           </div>
         </div>

--- a/mirage/helpers/django-html.js
+++ b/mirage/helpers/django-html.js
@@ -829,7 +829,7 @@ var HTML = `<html>
                           </div>
                           <!-- .nypr_lockup -->
                           <div class="sponsor">
-                              WNYC is supported by <img src="http://www.wnyc.org/i/raw/1/wnyc-footer.png">
+                              WNYC is supported by <img src="//www.wnyc.org/i/raw/1/wnyc-footer.png">
                           </div>
                           <ul class="nypr_copyright">
                               <li class="norule">&copy; 2016

--- a/tests/acceptance/settings-authenticated-test.js
+++ b/tests/acceptance/settings-authenticated-test.js
@@ -73,6 +73,7 @@ test('after visiting settings, user can toggle off autoplay settings', function(
 });
 
 test('if feature flag for autoplay-autoprefs is absent, then the link should be not be present', function(assert) {
+  server.create('django-page', {id: '/'});
   visit('/');
   const el = $('.l-bottom .list-item:contains("Settings")');
   andThen(() => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6582,7 +6582,7 @@ nypr-player@nypublicradio/nypr-player:
 
 nypr-publisher-lib@nypublicradio/nypr-publisher-lib:
   version "0.0.0"
-  resolved "https://codeload.github.com/nypublicradio/nypr-publisher-lib/tar.gz/19336c4c792aa23c2bc5c1856010041d40a19d68"
+  resolved "https://codeload.github.com/nypublicradio/nypr-publisher-lib/tar.gz/980293fd5e0891d547b43d0b1f590dba00c27c5f"
   dependencies:
     ember-cli-babel "^6.3.0"
     ember-cli-htmlbars "^2.0.1"


### PR DESCRIPTION
Replaced protocol-specific reference to JL Greene image in footer w/ profile-agnostic one, then found tests wouldn't pass, so fixed failing test, and ran yarn nypr-upgrade while I was in there.