### PR TITLE
Update channel redirects

### DIFF
--- a/app/channel/route.js
+++ b/app/channel/route.js
@@ -37,11 +37,10 @@ export default Route.extend(PlayParamMixin, {
 
   afterModel({ channel }, transition) {
     if (channel) {
-      let canonicalUrl = get(channel, 'url');
-      let canonicalHost = canonicalUrl && canonicalUrl.match(/\/\/([\w.]+)\//).pop();
+      let canonicalHost = get(channel, 'canonicalHost');
       if  (canonicalHost && canonicalHost !== document.location.host) {
         transition.abort();
-        window.location.href = canonicalUrl;
+        window.location.href = get(channel, 'url');
         return;
       }
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3434,12 +3434,6 @@ ember-invoke-action@^1.4.0:
   dependencies:
     ember-cli-babel "^5.1.6"
 
-ember-keyboard@2.1.9:
-  version "2.1.9"
-  resolved "https://registry.yarnpkg.com/ember-keyboard/-/ember-keyboard-2.1.9.tgz#52a810b749d23ca5bafd4484fd101bf0b73811ab"
-  dependencies:
-    ember-cli-babel "^5.1.6"
-
 ember-load-initializers@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/ember-load-initializers/-/ember-load-initializers-1.0.0.tgz#4919eaf06f6dfeca7e134633d8c05a6c9921e6e7"
@@ -6594,7 +6588,7 @@ nypr-audio-services@~0.0.0:
     ember-get-config "^0.2.2"
     ember-simple-auth "^1.4.0"
 
-nypr-django-for-ember@nypublicradio/nypr-django-for-ember:
+"nypr-django-for-ember@github:nypublicradio/nypr-django-for-ember", nypr-django-for-ember@nypublicradio/nypr-django-for-ember:
   version "0.0.0"
   resolved "https://codeload.github.com/nypublicradio/nypr-django-for-ember/tar.gz/e99534f68deb8cf9f1921bab4bd194aa16391749"
   dependencies:
@@ -6621,12 +6615,13 @@ nypr-player@nypublicradio/nypr-player:
     ember-cli-moment-shim "^3.4.0"
     ember-cli-sass "^7.0.0"
     ember-hifi "^1.11.1"
+    ember-keyboard "2.1.9"
     ember-moment "^7.4.1"
-    nypr-ui nypublicradio/nypr-ui
+    nypr-ui nypublicradio/nypr-ui#demo
 
 nypr-publisher-lib@~0.0.0:
-  version "0.0.3"
-  resolved "https://registry.yarnpkg.com/nypr-publisher-lib/-/nypr-publisher-lib-0.0.3.tgz#d142ebc25f194c1a3866c151ba92bb5f44486070"
+  version "0.0.5"
+  resolved "https://registry.yarnpkg.com/nypr-publisher-lib/-/nypr-publisher-lib-0.0.5.tgz#459d6ab0d605e8d3bcedb0027165e778b78bc6b6"
   dependencies:
     ember-cli-babel "^6.3.0"
     ember-cli-htmlbars "^2.0.1"
@@ -6657,21 +6652,6 @@ nypr-publisher-lib@~0.0.0:
 nypr-ui@nypublicradio/nypr-ui:
   version "0.0.0"
   resolved "https://codeload.github.com/nypublicradio/nypr-ui/tar.gz/19c5bb2333944a51fcba9cf94bbf2aec6c6d2670"
-  dependencies:
-    ember-basic-dropdown "0.33.1"
-    ember-cli-babel "^6.6.0"
-    ember-cli-htmlbars "^2.0.1"
-    ember-cli-htmlbars-inline-precompile "^0.4.3"
-    ember-cli-sass "^7.0.0"
-    ember-click-outside "0.1.9"
-    ember-composable-helpers "2.0.1"
-    ember-holygrail-layout "^0.1.4"
-    ember-power-select "^1.9.2"
-    ivy-tabs "3.1.0"
-
-nypr-ui@nypublicradio/nypr-ui#demo:
-  version "0.0.0"
-  resolved "https://codeload.github.com/nypublicradio/nypr-ui/tar.gz/c504af1debd1670df12869fcf34eb6103b1f48fe"
   dependencies:
     ember-basic-dropdown "0.33.1"
     ember-cli-babel "^6.6.0"


### PR DESCRIPTION
Now using canonicalHost from the channel model in nypr-publisher-lib v0.0.5

No more unsafe pops