### PR TITLE
Gothamist UTM params

### DIFF
--- a/app/helpers/append-query.js
+++ b/app/helpers/append-query.js
@@ -1,0 +1,34 @@
+import { helper } from '@ember/component/helper';
+
+export function appendQuery([url = '', queryToAdd = '']/*, hash*/) {
+  if (typeof url !== 'string' || typeof queryToAdd !== 'string') {
+    return url;
+  }
+
+  // string any beginning ? characters
+  queryToAdd = queryToAdd.replace(/^\?/, '');
+
+  if (/\?$/.test(url)) {
+    // incoming url ends with a ?, just jam on the query string
+    return `${url}${queryToAdd}`;
+  }
+
+  // does a query string exist?
+  let [address, foundQuery] = url.split('?');
+
+  if (/\?/.test(address) || /\?/.test(foundQuery)) {
+    // found a query string in the url or the query params
+    // weird case, just bail out
+    return url;
+  }
+
+  if (foundQuery) {
+    // there's already a query string on the url, add it to the params
+    return `${url}&${queryToAdd}`;
+  } else {
+    // no query string, make one
+    return `${url}?${queryToAdd}`;
+  }
+}
+
+export default helper(appendQuery);

--- a/app/helpers/append-query.js
+++ b/app/helpers/append-query.js
@@ -14,9 +14,9 @@ export function appendQuery([url = '', queryToAdd = '']/*, hash*/) {
   }
 
   // does a query string exist?
-  let [address, foundQuery] = url.split('?');
+  let [, foundQuery, ...extra] = url.split('?');
 
-  if (/\?/.test(address) || /\?/.test(foundQuery)) {
+  if (extra.length > 0) {
     // found a query string in the url or the query params
     // weird case, just bail out
     return url;

--- a/app/templates/index.hbs
+++ b/app/templates/index.hbs
@@ -19,7 +19,7 @@
 
       {{#row.items items=model.gothamist as |story|}}
         {{#story-card
-          href=(append-query story.permalink 'utm_medium=partnersite&utm_source=gothamist&utm_campaign=homepagepromo')
+          href=(append-query story.permalink 'utm_medium=partnersite&utm_source=wnyc&utm_campaign=homepagepromo')
           class="gtm__click-tracking"
           data-category="Homepage Bucket"
           data-action="gothamist"

--- a/app/templates/index.hbs
+++ b/app/templates/index.hbs
@@ -15,7 +15,7 @@
 
   {{#ember-wormhole to='gothamist-row'}}
     {{#story-row as |row|}}
-      {{#row.label}}Latest From <a href="https://www.gothamist.com">Gothamist</a>{{/row.label}}
+      {{#row.label}}Latest From <a href="https://www.gothamist.com?utm_medium=partnersite&utm_source=wnyc&utm_campaign=homepagepromo">Gothamist</a>{{/row.label}}
 
       {{#row.items items=model.gothamist as |story|}}
         {{#story-card

--- a/app/templates/index.hbs
+++ b/app/templates/index.hbs
@@ -18,7 +18,12 @@
       {{#row.label}}Latest From <a href="https://www.gothamist.com">Gothamist</a>{{/row.label}}
 
       {{#row.items items=model.gothamist as |story|}}
-        {{#story-card href=story.permalink class="gtm__click-tracking" data-category="Homepage Bucket" data-action="gothamist" data-label=story.title as |card|}}
+        {{#story-card
+          href=(append-query story.permalink 'utm_medium=partnersite&utm_source=gothamist&utm_campaign=homepagepromo')
+          class="gtm__click-tracking"
+          data-category="Homepage Bucket"
+          data-action="gothamist"
+          data-label=story.title as |card|}}
           {{card.image width=300 src=(make-https story.thumbnail_300)}}
           {{#card.body}}
             {{story.title}}

--- a/tests/integration/helpers/append-query-test.js
+++ b/tests/integration/helpers/append-query-test.js
@@ -1,0 +1,42 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+
+module('Integration | Helper | append-query', function(hooks) {
+  setupRenderingTest(hooks);
+
+  test('it appends a query string to the value', async function(assert) {
+    this.setProperties({
+      url: 'http://example.com',
+      query: 'foo=bar&cats=dogs',
+    });
+
+    await render(hbs`{{append-query url query}}`);
+
+    assert.equal(this.element.textContent.trim(), 'http://example.com?foo=bar&cats=dogs', 'adds a ? if the url does not have one');
+
+    this.set('url', 'http://example.com?buz=baz');
+
+    await render(hbs`{{append-query url query}}`);
+    assert.equal(this.element.textContent.trim(), 'http://example.com?buz=baz&foo=bar&cats=dogs', 'adds to a query string if one already exists on the url');
+
+    this.set('query', '?so=what');
+
+    await render(hbs`{{append-query url query}}`);
+    assert.equal(this.element.textContent.trim(), 'http://example.com?buz=baz&so=what', 'adds to a query string if one already exists on the query');
+  });
+
+  test('unexpected values are ok', async function(assert) {
+    await render(hbs`{{append-query url query}}`);
+    assert.ok('can render undefined');
+
+    this.setProperties({
+      url: {some: 'value', not: ['a string']},
+      query: 100
+    });
+
+    await render(hbs`{{append-query url query}}`);
+    assert.ok('can handle non-strings and complex objects');
+  });
+});


### PR DESCRIPTION
[ticket](https://jira.wnyc.org/browse/RT-757)

this adds an append-query helper to catch any weird edge cases when adding query strings to a given url. maybe the url already ends in a `?`. maybe the url already has query params, etc.