### PR TITLE
RT-908 change footer podcast link

### DIFF
--- a/app/components/site-chrome/site-footer/template.hbs
+++ b/app/components/site-chrome/site-footer/template.hbs
@@ -103,6 +103,7 @@
                    <li class="list-item list-item--tiny">
                     <a href="https://www.wnycstudios.org"
                       class="link--capbold"
+                      target="_blank"
                       title="Podcasts">
                       Podcasts
                     </a>

--- a/app/components/site-chrome/site-footer/template.hbs
+++ b/app/components/site-chrome/site-footer/template.hbs
@@ -101,7 +101,7 @@
                     </a>
                   </li>
                    <li class="list-item list-item--tiny">
-                    <a href="/audio/podcasts"
+                    <a href="https://www.wnycstudios.org"
                       class="link--capbold"
                       title="Podcasts">
                       Podcasts


### PR DESCRIPTION
Replaces the intermediary /audio/podcasts/ redirect URL in favor of a direct link to wnycstudios.org.