### PR TITLE
Kate/rt 941

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
     "nypr-metrics": "<0.1.0",
     "nypr-player": ">=0.2.0",
     "nypr-publisher-lib": ">=0.3.5",
-    "nypr-ui": "nypublicradio/nypr-ui#kate/RT-941",
+    "nypr-ui": "^0.2.19",
     "torii": "^0.10.1"
   },
   "ember-addon": {
@@ -122,7 +122,10 @@
     "nypr-django-for-ember": ">=0.2.0",
     "nypr-metrics": "<0.1.0",
     "nypr-publisher-lib": ">=0.3.5",
-    "nypr-ui": "nypublicradio/nypr-ui#kate/RT-941",
+    "nypr-ui": "^0.2.19",
+    "customizr": "Modernizr/customizr#e5890ed4b4fedb69da50ffbae39577788970d8ee"
+  },
+  "dependencies": {
     "customizr": "Modernizr/customizr#e5890ed4b4fedb69da50ffbae39577788970d8ee"
   }
 }

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "ember-sortable": "^1.11.2",
     "ember-source": "~3.0.0",
     "ember-truth-helpers": "^2.0.0",
-    "ember-waypoints": "nypublicradio/ember-waypoints",
+    "ember-waypoints": "nypublicradio/ember-waypoints#master",
     "ember-wormhole": "^0.5.4",
     "eslint-plugin-ember": "^5.0.0",
     "glob": "7.1.1",
@@ -102,7 +102,7 @@
     "nypr-metrics": "<0.1.0",
     "nypr-player": ">=0.2.0",
     "nypr-publisher-lib": ">=0.3.5",
-    "nypr-ui": ">=0.2.18",
+    "nypr-ui": "nypublicradio/nypr-ui#kate/RT-941",
     "torii": "^0.10.1"
   },
   "ember-addon": {
@@ -122,7 +122,7 @@
     "nypr-django-for-ember": ">=0.2.0",
     "nypr-metrics": "<0.1.0",
     "nypr-publisher-lib": ">=0.3.5",
-    "nypr-ui": ">=0.2.18",
+    "nypr-ui": "nypublicradio/nypr-ui#kate/RT-941",
     "customizr": "Modernizr/customizr#e5890ed4b4fedb69da50ffbae39577788970d8ee"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3650,9 +3650,9 @@ ember-validators@^1.0.0:
     ember-cli-babel "^6.9.2"
     ember-require-module "^0.2.0"
 
-ember-waypoints@nypublicradio/ember-waypoints:
+ember-waypoints@nypublicradio/ember-waypoints#master:
   version "0.1.0"
-  resolved "https://codeload.github.com/nypublicradio/ember-waypoints/tar.gz/879312e0028bc415d376b1a3eeecae04ac30e905"
+  resolved "https://codeload.github.com/nypublicradio/ember-waypoints/tar.gz/afffe721c401a6b784640d59a73a9ed4451e7248"
   dependencies:
     ember-cli-babel "^6.6.0"
     waypoints "^4.0.1"
@@ -6921,9 +6921,9 @@ nypr-publisher-lib@>=0.3.5:
     nypr-django-for-ember ">=0.1.0"
     nypr-ui ">=0.2.4"
 
-nypr-ui@>=0.2.0, nypr-ui@>=0.2.18, nypr-ui@>=0.2.4:
+nypr-ui@>=0.2.0, nypr-ui@>=0.2.4, nypr-ui@nypublicradio/nypr-ui#kate/RT-941:
   version "0.2.18"
-  resolved "https://registry.yarnpkg.com/nypr-ui/-/nypr-ui-0.2.18.tgz#6bc9a737bba33b44cfd35c200e0a4b45444815da"
+  resolved "https://codeload.github.com/nypublicradio/nypr-ui/tar.gz/8ab746e5213b4d2c4084850f73a4bbf3a2f36a6b"
   dependencies:
     ember-basic-dropdown "0.34.0"
     ember-burger-menu "^3.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3654,8 +3654,7 @@ ember-waypoints@nypublicradio/ember-waypoints#master:
   version "0.1.0"
   resolved "https://codeload.github.com/nypublicradio/ember-waypoints/tar.gz/afffe721c401a6b784640d59a73a9ed4451e7248"
   dependencies:
-    ember-cli-babel "^6.6.0"
-    waypoints "^4.0.1"
+    ember-cli-babel "^5.1.3"
 
 ember-weakmap@^3.0.0:
   version "3.2.0"
@@ -6921,9 +6920,9 @@ nypr-publisher-lib@>=0.3.5:
     nypr-django-for-ember ">=0.1.0"
     nypr-ui ">=0.2.4"
 
-nypr-ui@>=0.2.0, nypr-ui@>=0.2.4, nypr-ui@nypublicradio/nypr-ui#kate/RT-941:
-  version "0.2.18"
-  resolved "https://codeload.github.com/nypublicradio/nypr-ui/tar.gz/8ab746e5213b4d2c4084850f73a4bbf3a2f36a6b"
+nypr-ui@>=0.2.0, nypr-ui@>=0.2.4, nypr-ui@^0.2.19:
+  version "0.2.19"
+  resolved "https://registry.yarnpkg.com/nypr-ui/-/nypr-ui-0.2.19.tgz#cdb28b7c24299195f50ddadc9555239a8c879199"
   dependencies:
     ember-basic-dropdown "0.34.0"
     ember-burger-menu "^3.1.0"


### PR DESCRIPTION
This bumps the nypr-ui version to get the new NJPR logo for https://jira.wnyc.org/browse/RT-928 and a mobile fix for https://jira.wnyc.org/browse/RT-941