### PR TITLE
global promo design QA

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,11 +99,11 @@
     "nypr-audio-services": ">=0.4.0",
     "nypr-auth": ">=0.2.3",
     "nypr-django-for-ember": ">=0.3.0",
-    "nypr-election-countdown": "nypublicradio/nypr-election-countdown#kate/RT-1042-promo",
+    "nypr-election-countdown": ">=0.2.5",
     "nypr-metrics": ">=0.4.0",
     "nypr-player": ">=0.3.0",
     "nypr-publisher-lib": ">=0.4.1",
-    "nypr-ui": "nypublicradio/nypr-ui#kate/right-arrow",
+    "nypr-ui": ">=0.4.1",
     "torii": "^0.10.1"
   },
   "ember-addon": {

--- a/package.json
+++ b/package.json
@@ -99,11 +99,11 @@
     "nypr-audio-services": ">=0.4.0",
     "nypr-auth": ">=0.2.3",
     "nypr-django-for-ember": ">=0.3.0",
-    "nypr-election-countdown": ">=0.2.4",
+    "nypr-election-countdown": "nypublicradio/nypr-election-countdown#kate/RT-1042-promo",
     "nypr-metrics": ">=0.4.0",
     "nypr-player": ">=0.3.0",
     "nypr-publisher-lib": ">=0.4.1",
-    "nypr-ui": ">=0.3.0",
+    "nypr-ui": "nypublicradio/nypr-ui#kate/right-arrow",
     "torii": "^0.10.1"
   },
   "ember-addon": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7171,9 +7171,9 @@ nypr-django-for-ember@>=0.3.0:
     ember-cli-htmlbars "^2.0.1"
     ember-wormhole "^0.5.2"
 
-nypr-election-countdown@>=0.2.4:
+nypr-election-countdown@nypublicradio/nypr-election-countdown#kate/RT-1042-promo:
   version "0.2.4"
-  resolved "https://registry.yarnpkg.com/nypr-election-countdown/-/nypr-election-countdown-0.2.4.tgz#0e2b89bffed8e008abb6a20755629f29498d8a4e"
+  resolved "https://codeload.github.com/nypublicradio/nypr-election-countdown/tar.gz/35f8b20ec450604d5233098b9b538867267bca49"
   dependencies:
     "@fortawesome/ember-fontawesome" "^0.1.2"
     "@fortawesome/free-brands-svg-icons" "^5.2.0"
@@ -7248,6 +7248,24 @@ nypr-publisher-lib@>=0.4.2:
 nypr-ui@>=0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/nypr-ui/-/nypr-ui-0.3.0.tgz#76e4eb992ef28ab24d29ca8314f0fad7d8134af4"
+  dependencies:
+    ember-basic-dropdown "0.34.0"
+    ember-burger-menu "^3.1.0"
+    ember-cli-babel "^6.8.0"
+    ember-cli-htmlbars "^2.0.1"
+    ember-cli-htmlbars-inline-precompile "^1.0.0"
+    ember-cli-sass "^7.1.7"
+    ember-click-outside "0.1.11"
+    ember-composable-helpers "2.0.3"
+    ember-cookies "^0.3.0"
+    ember-holygrail-layout "^0.3.0"
+    ember-power-select "^1.9.2"
+    ivy-tabs "^3.3.0"
+    waypoints "^4.0.1"
+
+nypr-ui@nypublicradio/nypr-ui#kate/right-arrow:
+  version "0.4.0"
+  resolved "https://codeload.github.com/nypublicradio/nypr-ui/tar.gz/a3b791de94f61112035921f4fdec8004d8d01b02"
   dependencies:
     ember-basic-dropdown "0.34.0"
     ember-burger-menu "^3.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7171,9 +7171,9 @@ nypr-django-for-ember@>=0.3.0:
     ember-cli-htmlbars "^2.0.1"
     ember-wormhole "^0.5.2"
 
-nypr-election-countdown@nypublicradio/nypr-election-countdown#kate/RT-1042-promo:
-  version "0.2.4"
-  resolved "https://codeload.github.com/nypublicradio/nypr-election-countdown/tar.gz/b9e9901da6913201669561d245078ff211718729"
+nypr-election-countdown@>=0.2.5:
+  version "0.2.5"
+  resolved "https://registry.yarnpkg.com/nypr-election-countdown/-/nypr-election-countdown-0.2.5.tgz#8560bfa9e2b340099e2c404ff45ead0ef8dfface"
   dependencies:
     "@fortawesome/ember-fontawesome" "^0.1.2"
     "@fortawesome/free-brands-svg-icons" "^5.2.0"
@@ -7263,9 +7263,9 @@ nypr-ui@>=0.3.0:
     ivy-tabs "^3.3.0"
     waypoints "^4.0.1"
 
-nypr-ui@nypublicradio/nypr-ui#kate/right-arrow:
-  version "0.4.0"
-  resolved "https://codeload.github.com/nypublicradio/nypr-ui/tar.gz/a3b791de94f61112035921f4fdec8004d8d01b02"
+nypr-ui@>=0.4.1:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/nypr-ui/-/nypr-ui-0.4.1.tgz#d121ea922525c574a20e93d7794bccbfd0da74a1"
   dependencies:
     ember-basic-dropdown "0.34.0"
     ember-burger-menu "^3.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7173,7 +7173,7 @@ nypr-django-for-ember@>=0.3.0:
 
 nypr-election-countdown@nypublicradio/nypr-election-countdown#kate/RT-1042-promo:
   version "0.2.4"
-  resolved "https://codeload.github.com/nypublicradio/nypr-election-countdown/tar.gz/7d5c6110e8a24b52bcdc1e161a93662b4ee7367c"
+  resolved "https://codeload.github.com/nypublicradio/nypr-election-countdown/tar.gz/b9e9901da6913201669561d245078ff211718729"
   dependencies:
     "@fortawesome/ember-fontawesome" "^0.1.2"
     "@fortawesome/free-brands-svg-icons" "^5.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7173,7 +7173,7 @@ nypr-django-for-ember@>=0.3.0:
 
 nypr-election-countdown@nypublicradio/nypr-election-countdown#kate/RT-1042-promo:
   version "0.2.4"
-  resolved "https://codeload.github.com/nypublicradio/nypr-election-countdown/tar.gz/35f8b20ec450604d5233098b9b538867267bca49"
+  resolved "https://codeload.github.com/nypublicradio/nypr-election-countdown/tar.gz/7d5c6110e8a24b52bcdc1e161a93662b4ee7367c"
   dependencies:
     "@fortawesome/ember-fontawesome" "^0.1.2"
     "@fortawesome/free-brands-svg-icons" "^5.2.0"


### PR DESCRIPTION
This PR bumps `nypr-ui` and `nypr-election-countdown` versions in order to get some visual enhancements. `nypr-ui` takes a biggish jump to a fastboot-supported version, but according to Matt W "it should be ok if tests pass. ideally, the fastboot fixes shouldn’t change how anything works." 