### PR TITLE
Add ability to test DFP units on WNYC

### DIFF
--- a/app/channel/template.hbs
+++ b/app/channel/template.hbs
@@ -1,7 +1,7 @@
 {{#unless model.channel.altLayout}}
   {{dfp-ad
     slotClassNames="is-collapsed l-constrained aligncenter leaderboard"
-    slot="/6483581/leaderboard/wnyc_leaderboard"
+    slot=(concat googleDFPPrefix "leaderboard/wnyc_leaderboard")
     target="leaderboard"
     mapping=(array (array 0 (array 300 50)) (array 758 (array 728 90)) (array 1203 (array 970 415)))
     sizes=(array (array 970 415) (array 728 90) (array 300 50))}}
@@ -98,7 +98,7 @@
 
       {{dfp-ad
         slotClassNames="align--mq-centertoright channel-ad"
-        slot="/6483581/rectangle/wnyc_rectangle"
+        slot=(concat googleDFPPrefix "rectangle/wnyc_rectangle")
         target="rightRail"
         sizes=(array (array 300 250) (array 300 600))}}
 

--- a/app/instance-initializers/dfp-config.js
+++ b/app/instance-initializers/dfp-config.js
@@ -1,0 +1,24 @@
+import config from '../config/environment';
+
+export function initialize(appInstance) {
+  // for now, nypr-ads and wnyc-web-client don't
+  // have native support for either distinct
+  // account IDs or 'test' ad unit prefixes
+  // so the googleDFPPrefix defined in either
+  // .env or otherwise in the environment provides
+  // a crude way to do both at once without breaking
+  // anything, as the default (in environment.js)
+  // will just pass in a properly-formatted string
+  // TODO: get required DFP account ID, throw
+  // error if empty, take optional 'test prefix'
+  // path, construct proper string for nypr-ads
+  let googleDFPPrefix = config.googleDFPPrefix;
+  appInstance.register('dfp-config:main', googleDFPPrefix, { singleton: true, instantiate: false });
+  appInstance.inject('controller', 'googleDFPPrefix', 'dfp-config:main');
+
+}
+
+export default {
+  name: 'dfp-config',
+  initialize
+};

--- a/app/playlist/template.hbs
+++ b/app/playlist/template.hbs
@@ -1,6 +1,6 @@
 {{dfp-ad
   slotClassNames="is-collapsed l-constrained aligncenter leaderboard"
-  slot="/6483581/leaderboard/wnyc_leaderboard"
+  slot=(concat googleDFPPrefix "leaderboard/wnyc_leaderboard")
   target="leaderboard"
   mapping=(array (array 0 (array 300 50)) (array 758 (array 728 90)) (array 1203 (array 970 415)))
   sizes=(array (array 970 415) (array 728 90) (array 300 50))}}
@@ -13,7 +13,7 @@
     <div class="l-skinny">
       {{dfp-ad
         slotClassNames="align--mq-centertoright channel-ad"
-        slot="/6483581/rectangle/wnyc_rectangle"
+        slot=(concat googleDFPPrefix "rectangle/wnyc_rectangle")
         target="rightRail"
         sizes=(array (array 300 250) (array 300 600))}}
     </div>

--- a/app/router.js
+++ b/app/router.js
@@ -6,7 +6,7 @@ const Router = EmberRouter.extend({
   session:      service(),
   location: config.locationType,
   rootURL: config.rootURL,
-  
+
   willTransition(oldInfos, newInfos, transition) {
     this._super(...arguments);
     if (!['login', 'signup', 'validate', 'forgot', 'reset', 'set-password'].includes(transition.targetName)) {

--- a/app/schedule/date/template.hbs
+++ b/app/schedule/date/template.hbs
@@ -1,6 +1,6 @@
 {{dfp-ad
   slotClassNames="is-collapsed l-constrained aligncenter leaderboard"
-  slot="/6483581/leaderboard/wnyc_leaderboard"
+  slot=(concat googleDFPPrefix "leaderboard/wnyc_leaderboard")
   target="leaderboard"
   mapping=(array (array 0 (array 300 50)) (array 758 (array 728 90)) (array 1203 (array 970 415)))
   sizes=(array (array 970 415) (array 728 90) (array 300 50))}}

--- a/app/show/template.hbs
+++ b/app/show/template.hbs
@@ -19,7 +19,7 @@
 
 {{dfp-ad
   slotClassNames="is-collapsed l-constrained aligncenter leaderboard"
-  slot="/6483581/leaderboard/wnyc_leaderboard"
+  slot=(concat googleDFPPrefix "leaderboard/wnyc_leaderboard")
   target="leaderboard"
   mapping=(array (array 0 (array 300 50)) (array 758 (array 728 90)) (array 1203 (array 970 415)))
   sizes=(array (array 970 415) (array 728 90) (array 300 50))}}

--- a/app/story/template.hbs
+++ b/app/story/template.hbs
@@ -1,6 +1,6 @@
 {{dfp-ad
   slotClassNames="is-collapsed l-constrained aligncenter leaderboard"
-  slot="/6483581/leaderboard/wnyc_leaderboard"
+  slot=(concat googleDFPPrefix "leaderboard/wnyc_leaderboard")
   target="leaderboard"
   mapping=(array (array 0 (array 300 50)) (array 758 (array 728 90)) (array 1203 (array 970 415)))
   sizes=(array (array 970 415) (array 728 90) (array 300 50))}}
@@ -191,7 +191,7 @@
 
         {{dfp-ad
           slotClassNames="align--mq-centertoright right-rail"
-          slot="/6483581/rectangle/wnyc_rectangle"
+          slot=(concat googleDFPPrefix "rectangle/wnyc_rectangle")
           target="rightRail"
           sizes=(array (array 300 250) (array 300 600))}}
 

--- a/app/stream/template.hbs
+++ b/app/stream/template.hbs
@@ -1,6 +1,6 @@
 {{dfp-ad
   slotClassNames="is-collapsed l-constrained aligncenter leaderboard"
-  slot="/6483581/leaderboard/wnyc_leaderboard"
+  slot=(concat googleDFPPrefix "leaderboard/wnyc_leaderboard")
   target="leaderboard"
   mapping=(array (array 0 (array 300 50)) (array 758 (array 728 90)) (array 1203 (array 970 415)))
   sizes=(array (array 970 415) (array 728 90) (array 300 50))}}
@@ -13,7 +13,7 @@
   <aside class="l-col1of3">
     <div class="l-skinny">
       {{dfp-ad
-        slot="/6483581/rectangle/wnyc_rectangle"
+        slot=(concat googleDFPPrefix "rectangle/wnyc_rectangle")
         target="rightRail"
         sizes=(array (array 300 250) (array 300 600))}}
     </div>

--- a/app/templates/index.hbs
+++ b/app/templates/index.hbs
@@ -1,6 +1,6 @@
 {{dfp-ad
   slotClassNames="is-collapsed l-constrained aligncenter leaderboard"
-  slot="/6483581/leaderboard/wnyc_leaderboard"
+  slot=(concat googleDFPPrefix "leaderboard/wnyc_leaderboard")
   target="leaderboard"
   mapping=(array (array 0 (array 300 50)) (array 758 (array 728 90)) (array 1203 (array 970 90) (array 970 415)))
   sizes=(array (array 970 415) (array 970 90) (array 728 90) (array 300 50))}}

--- a/config/environment.js
+++ b/config/environment.js
@@ -107,7 +107,8 @@ module.exports = function(environment) {
       enabled: environment === 'production',
       forceSSL: true
     },
-    googleTagManager: process.env.GOOGLE_TAG_MANAGER_ID || 'GTM-PM94N2'
+    googleTagManager: process.env.GOOGLE_TAG_MANAGER_ID || 'GTM-PM94N2',
+    googleDFPPrefix: process.env.GOOGLE_DFP_PREFIX || '/6483581/'
   };
 
   if (environment === 'development') {

--- a/tests/unit/instance-initializers/dfp-config-test.js
+++ b/tests/unit/instance-initializers/dfp-config-test.js
@@ -1,0 +1,29 @@
+import Application from '@ember/application';
+
+import { initialize } from 'wnyc-web-client/instance-initializers/dfp-config';
+import { module, test } from 'qunit';
+import destroyApp from '../../helpers/destroy-app';
+
+module('Unit | Instance Initializer | dfp-config', function(hooks) {
+
+  hooks.beforeEach(function() {
+    this.TestApplication = Application.extend();
+    this.TestApplication.instanceInitializer({
+      name: 'initializer under test',
+      initialize
+    });
+    this.application = this.TestApplication.create({ autoboot: false });
+    this.instance = this.application.buildInstance();
+  });
+  hooks.afterEach(function() {
+    destroyApp(this.application);
+    destroyApp(this.instance);
+  });
+
+  // Replace this with your real tests.
+  test('it works', async function(assert) {
+    await this.instance.boot();
+
+    assert.ok(true);
+  });
+});


### PR DESCRIPTION
Not too fancy, just adds ability to prefix DFP units for testing, includes safe default value that won't break ads in production.

Production:
`/{{dfp-id}}/slot-slug-1/slot-slug-2`

Test:
`/{{dfp-id}}/test-prefix/slot-slug-1/slot-slug-2`