### PR TITLE
Update wnyc_leaderboard size mapping

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@
 npm-debug.log*
 yarn-error.log
 testem.log
+.node-version
 
 # keep production keys out of repo
 .env

--- a/app/templates/index.hbs
+++ b/app/templates/index.hbs
@@ -2,7 +2,7 @@
   slotClassNames="is-collapsed l-constrained aligncenter leaderboard"
   slot="/6483581/leaderboard/wnyc_leaderboard"
   target="leaderboard"
-  mapping=(array (array 0 (array 300 50)) (array 758 (array 728 90)) (array 1203 (array 970 90) (array 970 415)))
+  mapping=(array (array 0 (array 300 50)) (array 758 (array 728 90)) (array 1203 (array (array 970 90) (array 970 415))))
   sizes=(array (array 970 415) (array 970 90) (array 728 90) (array 300 50))}}
 
 {{#django-page page=model.page class='l-constrained'}}


### PR DESCRIPTION
Small update that changes the size mapping for wnyc_leaderboard to put the 970x90 and 970x415 under one `array`, rather than passing them as individual arguments