### PR TITLE
SUP- 5991 Color h2 text white in the stream banner card

### DIFF
--- a/app/styles/_stream-widget.scss
+++ b/app/styles/_stream-widget.scss
@@ -12,6 +12,7 @@
 }
 
 #wnyc_home .stream-banner .stream-banner-card .stream-banner-details h2 {
+  color: $white;
   font-weight: 600;
 }
 


### PR DESCRIPTION
Some of the titles inn the stream banner were getting their text colored black due to a conflicting css rule from the home page that was trying to make all h2s on the home page colored black.