### PR TITLE
Add the WNYC March Store link

### DIFF
--- a/app/components/site-chrome/template.hbs
+++ b/app/components/site-chrome/template.hbs
@@ -99,6 +99,11 @@
         {{#link-to 'discover.start' current-when="discover" tagName='li' href=false class="list-item list-item--nav"}}
           {{link-to 'Discover' 'discover.start' class="inherit gtm__click-tracking" data-action="Side Navigation"}}
         {{/link-to}}
+        
+        <li class="list-item list-item--nav">
+          <a href="https://shop.wnyc.org" id="merch-store-a-tag" class="inherit gtm__click-tracking merch-store-link"
+            target="_blank" data-action="Side Navigation"><span><i class="fa fa-external-link" aria-hidden="true"></i></span>Shop</a> 
+        </li>
 
         <li class="list-item list-item--nav">
           <a href="https://www.nypublicradio.org/support/" class="inherit gtm__click-tracking" data-action="Side Navigation"


### PR DESCRIPTION
Adding a link to the WNYC pop-up merch store to the sidebar. This should be timed to go out when the merch store goes live.