### PR TITLE
Adding a space

### DIFF
--- a/app/components/site-chrome/template.hbs
+++ b/app/components/site-chrome/template.hbs
@@ -102,7 +102,7 @@
         
         <li class="list-item list-item--nav">
           <a href="https://shop.wnyc.org" id="merch-store-a-tag" class="inherit gtm__click-tracking merch-store-link"
-            data-action="Side Navigation" target="_blank" rel="noopener"><span><i class="fa fa-external-link" aria-hidden="true"></i></span>Shop</a> 
+            data-action="Side Navigation" target="_blank" rel="noopener"><span><i class="fa fa-external-link" aria-hidden="true"></i></span> Shop</a> 
         </li>
 
         <li class="list-item list-item--nav">


### PR DESCRIPTION
While QAing the merch store link I noticed we needed an extra space between the word "Shop" and the external link indicator.

QA link for the last pull request was here:  https://wnyc.demo2.wnyc.net/?build=wnyc/sguzik-merch-store