### PR TITLE
Adds New Sounds styles to WNYC.org

### DIFF
--- a/app/channel/template.hbs
+++ b/app/channel/template.hbs
@@ -25,13 +25,15 @@
 
   {{/alt-channel-layout}}
 {{else}}
-  {{#if model.channel.hasMarquee}}
-    {{x-marquee listenLive=model.listenLive.pagecontent model=model.channel isStaff=session.data.isStaff adminURL=adminURL}}
-  {{else}}
-    {{channel-header listenLive=model.listenLive.pagecontent model=model.channel isStaff=session.data.isStaff adminURL=adminURL classNames=(unless model.channel.featured 'flush')}}
-  {{/if}}
+  <div class="{{model.channel.slug}}">
+    {{#if model.channel.hasMarquee}}
+      {{x-marquee listenLive=model.listenLive.pagecontent model=model.channel isStaff=session.data.isStaff adminURL=adminURL}}
+    {{else}}
+      {{channel-header listenLive=model.listenLive.pagecontent model=model.channel isStaff=session.data.isStaff adminURL=adminURL classNames=(unless model.channel.featured 'flush')}}
+    {{/if}}
+  </div>
 
-<div class="l-constrained">
+<div class="l-constrained {{model.channel.slug}}">
   <main class="l-col2of3">
 
     {{#if model.channel.featured}}

--- a/app/styles/_newsounds.scss
+++ b/app/styles/_newsounds.scss
@@ -1,0 +1,46 @@
+.newsounds,
+.soundcheck,
+.gig-alerts {
+
+  .nav-bar {
+    background-color: black;
+  }
+
+  .listen-button {
+
+    &.blue-minion {
+      background-color: black;
+      border-color: black;
+      &:not([disabled]) {
+        &:hover,
+        &:focus {
+          background-color: #F042EA;
+          border-color: #F042EA;
+        }
+      }
+    }
+
+    &.blue-boss,
+    &.red-minion {
+      background-color: #F042EA;
+      border-color: #F042EA;
+      &:not([disabled]) {
+        &:hover,
+        &:focus {
+          background-color: rgb(242, 92, 237);
+          border-color: rgb(242, 92, 237);
+        }
+      }
+    }
+
+  }
+
+  .marquee-gradient {
+    background-image: radial-gradient(rgba(255, 255, 255,0) 200px, white 620px) !important;
+  }
+
+  .marquee-image {
+    background-color: white !important;
+  }
+
+}

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -85,6 +85,8 @@
 
 @import 'centennial';
 
+@import 'newsounds.scss';
+
 // Required for ember-component-css
 
 // LEGACY CODE


### PR DESCRIPTION
Per https://nypublicradio-digital.atlassian.net/browse/ACMS-474 and internal discussions, this PR makes a few template and CSS updates to the WNYC web client to support the New Sounds show pages on WNYC.org. There's a slug added to the channel template in order to target New Sounds specific styles to three show pages.

Given plans to replatform this site this year, the CSS was done in a pretty fast and loose way. It's not future-proof, but that should be OK for this short-term context.